### PR TITLE
Test release tools

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 Changes for bmi-topography
 ==========================
 
-0.1 (unreleased)
+0.1 (2021-02-22)
 ----------------
 
 * Created base library that calls OpenTopography API

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,1 @@
+# Changes for bmi-topography

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
-# Changes for bmi-topography
+Changes for bmi-topography
+==========================
 
 0.1
 ---

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,1 +1,8 @@
 # Changes for bmi-topography
+
+0.1
+
+* Created base library that calls OpenTopography API
+* Created CLI for library
+* Wrote tests for library and CLI
+* Included demo Jupyter Notebook for library

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes for bmi-topography
 
-0.1
+## 0.1
 
 * Created base library that calls OpenTopography API
 * Created CLI for library

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes for bmi-topography
 
-## 0.1
+0.1
+---
 
 * Created base library that calls OpenTopography API
 * Created CLI for library

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 Changes for bmi-topography
 ==========================
 
-0.1
----
+0.1 (unreleased)
+----------------
 
 * Created base library that calls OpenTopography API
 * Created CLI for library

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 Changes for bmi-topography
 ==========================
 
-0.1.1 (unreleased)
+0.1.1 (2021-02-22)
 ------------------
 
 * Added Makefile rule to test upload to TestPyPI

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 Changes for bmi-topography
 ==========================
 
+0.1.1 (unreleased)
+------------------
+
+* Added Makefile rule to test upload to TestPyPI
+* Tested upload to TestPyPI
+
+
 0.1 (2021-02-22)
 ----------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Changes for bmi-topography
 ==========================
 
+0.1.2 (unreleased)
+------------------
+
+- Nothing changed yet.
+
+
 0.1.1 (2021-02-22)
 ------------------
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,133 @@
+# Contributing
+
+Contributions are welcome, and they are greatly appreciated! Every
+little bit helps, and credit will always be given.
+
+You can contribute in many ways:
+
+## Types of Contributions
+
+### Report Bugs
+
+Report bugs at <https://github.com/csdms/bmi-topography/issues>.
+
+If you are reporting a bug, please include:
+
+-   Your operating system name and version.
+-   Any details about your local setup that might be helpful in
+    troubleshooting.
+-   Detailed steps to reproduce the bug.
+
+### Fix Bugs
+
+Look through the GitHub issues for bugs. Anything tagged with "bug"
+and "help wanted" is open to whoever wants to implement it.
+
+### Implement Features
+
+Look through the GitHub issues for features. Anything tagged with
+"enhancement" and "help wanted" is open to whoever wants to
+implement it.
+
+### Write Documentation
+
+*bmi-topography* could always use more documentation, whether as part of the
+official docs, in docstrings, or even on the web in blog
+posts, articles, and such.
+
+### Submit Feedback
+
+The best way to send feedback is to file an issue at
+<https://github.com/csdms/bmi-topography/issues>.
+
+If you are proposing a feature:
+
+-   Explain in detail how it would work.
+-   Keep the scope as narrow as possible, to make it easier to
+    implement.
+-   Remember that this is a volunteer-driven project, and that
+    contributions are welcome :)
+
+## Get Started!
+
+Ready to contribute? Here\'s how to set up *bmi-topography* for local
+development.
+
+1.  Fork the *bmi-topography* repo on GitHub.
+
+2.  Clone your fork locally:
+
+    ``` {.shell}
+    $ git clone git@github.com:your_name_here/bmi-topography.git
+    ```
+
+3.  Install your local copy into a conda environment. A conda enviroment file is
+    supplied at the root of the repository. Assuming you have conda installed,
+    this is how you set up your fork for local development:
+
+    ``` {.shell}
+    $ cd bmi-topography
+    $ conda env create --file=environment.yml
+    $ conda activate topography
+    $ make install
+    ```
+
+4.  Create a branch for local development:
+
+    ``` {.shell}
+    $ git checkout -b name-of-your-bugfix-or-feature
+    ```
+
+    Now you can make your changes locally.
+
+5.  When you're done making changes, check that your changes pass
+    flake8 and the tests:
+
+    ``` {.shell}
+    $ make lint
+    $ make test
+    ```
+
+    Both flake8 and pytest are included in the environment.
+
+6.  Commit your changes and push your branch to GitHub:
+
+    ``` {.shell}
+    $ git add .
+    $ git commit -m "Your detailed description of your changes."
+    $ git push origin name-of-your-bugfix-or-feature
+    ```
+
+7.  Submit a pull request through the GitHub website.
+
+## Pull Request Guidelines
+
+Before you submit a pull request, check that it meets these guidelines:
+
+1.  The pull request should include tests.
+2.  If the pull request adds functionality, the docs should be updated.
+    Put your new functionality into a function with a docstring, and add
+    the feature to the list in README.rst.
+3.  The pull request need only work with Python >= 3.8.
+
+
+## Deploying
+
+A reminder for the maintainers on how to deploy. To make a new release,
+you will need to have
+[zest.releaser](https://zestreleaser.readthedocs.io/en/latest/)
+installed, which can be installed with *pip*,
+
+``` {.bash}
+$ pip install zest.releaser[recommended]
+```
+
+Make sure all your changes are committed (including an entry in
+CHANGES.md). Then run,
+
+``` {.bash}
+$ fullrelease
+```
+
+This will create a new tag and alert the *bmi-topography* feedstock on
+*conda-forge* that there is a new release.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,6 @@
 include *.md
 include environment.yml
 include Makefile
+recursive-include examples *
 recursive-exclude docs *
-recursive-include tests *.py
-recursive-include tests *.toml
-recursive-include tests *.txt
-recursive-include tests *.cfg
-recursive-include tests *.yaml
+recursive-exclude tests *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+include *.md
+include environment.yml
+include Makefile
+recursive-exclude docs *
+recursive-include tests *.py
+recursive-include tests *.toml
+recursive-include tests *.txt
+recursive-include tests *.cfg
+recursive-include tests *.yaml

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ clean-build: ## remove build artifacts
 	rm -fr .eggs/
 	find . -name '*.egg-info' -exec rm -fr {} +
 	find . -name '*.egg' -exec rm -f {} +
+	rm -f setup.py
 
 clean-pyc: ## remove Python file artifacts
 	find . -name '*.pyc' -exec rm -f {} +
@@ -69,6 +70,16 @@ docs: ## generate Sphinx HTML documentation, including API docs and link check
 	$(MAKE) -C docs html
 	$(MAKE) -C docs linkcheck
 	$(BROWSER) docs/build/html/index.html
+
+setup: ## generate a setup.py file for release tools
+	echo "import setuptools" >> setup.py
+	echo "setuptools.setup()" >> setup.py
+
+prerelease: clean setup ## generate a prerelease with zest.releaser
+	prerelease
+
+fullrelease: clean setup ## generate a full release with zest.releaser
+	fullrelease
 
 install: clean ## install the package to the active Python's site-packages
 	pip install .

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ testrelease: clean setup ## build, package and upload a release
 	python setup.py sdist
 	python setup.py bdist_wheel
 	ls -l dist
-	twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+	twine upload --repository testpypi dist/*
 
 prerelease: clean setup ## generate a prerelease with zest.releaser
 	prerelease

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,12 @@ setup: ## generate a setup.py file for release tools
 	echo "import setuptools" >> setup.py
 	echo "setuptools.setup()" >> setup.py
 
+testrelease: clean setup ## build, package and upload a release
+	python setup.py sdist
+	python setup.py bdist_wheel
+	ls -l dist
+	twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
 prerelease: clean setup ## generate a prerelease with zest.releaser
 	prerelease
 

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ testrelease: clean setup ## build, package and upload a release
 	python setup.py sdist
 	python setup.py bdist_wheel
 	ls -l dist
-	twine upload --repository testpypi dist/*
+	twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
 prerelease: clean setup ## generate a prerelease with zest.releaser
 	prerelease

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bmi-topography
-version = 0.1.1
+version = 0.1.2.dev0
 author = Mark Piper
 author_email = mark.piper@colorado.edu
 description = Fetch and cache NASA SRTM land elevation data

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bmi-topography
-version = 0.1
+version = 0.1.1
 author = Mark Piper
 author_email = mark.piper@colorado.edu
 description = Fetch and cache NASA SRTM land elevation data


### PR DESCRIPTION
This PR adds rules to the Makefile for creating a release, as well as top-level package files to support releases.

Details:

* The Makefile includes rules for  zest.releaser prerelease and fullrelease commands
* Because zest.releaser requires a setup.py file, a rule is included to autogenerate one (and it clean up)
* The testrelease rule builds and uploads the package to TestPyPI

I downloaded the TestPyPI upload to check that the right files are included. 