### PR TITLE
Include shell script CLI example

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@ Changes for bmi-topography
 0.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
+* Install with conda
+* Include shell script demonstrating CLI
 
 
 0.3 (2021-02-25)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Basic Model Interface](https://img.shields.io/badge/CSDMS-Basic%20Model%20Interface-green.svg)](https://bmi.readthedocs.io/)
+![PyPI](https://img.shields.io/pypi/v/bmi-topography)
 [![Build/Test CI](https://github.com/csdms/bmi-topography/actions/workflows/build-test-ci.yml/badge.svg)](https://github.com/csdms/bmi-topography/actions/workflows/build-test-ci.yml)
 [![Documentation Status](https://readthedocs.org/projects/bmi-topography/badge/?version=latest)](https://bmi-topography.readthedocs.io/en/latest/?badge=latest)
 
@@ -40,6 +41,10 @@ Install the latest stable release of *bmi-topography* with `pip`:
 ```
 pip install bmi-topography
 ```
+or with `conda`:
+```
+conda install -c conda-forge bmi-topography
+```
 
 The *bmi-topography* library can also be built and installed from source.
 The library uses several other open source libraries,
@@ -52,7 +57,7 @@ and set up a conda environment with the included environment file:
 ```
 conda env create --file=environment.yml
 ```
-Then install *bmi-topography* with
+Then build and install *bmi-topography* from source with
 ```
 make install
 ```
@@ -127,7 +132,8 @@ Attributes:
 ```
 
 For examples with more detail,
-see the two Jupyter Notebooks
+see the two Jupyter Notebooks,
+Python script, and shell script
 included in the [examples](https://github.com/csdms/bmi-topography/tree/main/examples) directory
 of the *bmi-topography* repository.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Basic Model Interface](https://img.shields.io/badge/CSDMS-Basic%20Model%20Interface-green.svg)](https://bmi.readthedocs.io/)
-![PyPI](https://img.shields.io/pypi/v/bmi-topography)
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/bmi-topography.svg)](https://anaconda.org/conda-forge/bmi-topography)
+[![PyPI](https://img.shields.io/pypi/v/bmi-topography)](https://pypi.org/project/bmi-topography)
 [![Build/Test CI](https://github.com/csdms/bmi-topography/actions/workflows/build-test-ci.yml/badge.svg)](https://github.com/csdms/bmi-topography/actions/workflows/build-test-ci.yml)
 [![Documentation Status](https://readthedocs.org/projects/bmi-topography/badge/?version=latest)](https://bmi-topography.readthedocs.io/en/latest/?badge=latest)
 

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,3 +1,2 @@
 sphinx
 recommonmark
-pandoc

--- a/examples/bmi-topography_ex.sh
+++ b/examples/bmi-topography_ex.sh
@@ -1,0 +1,20 @@
+#! /usr/bin/env bash
+# Example of downloading data through the bmi-topography CLI.
+
+DEM_TYPE=SRTMGL3
+SOUTH=36.738884
+NORTH=38.091337
+WEST=-120.168457
+EAST=-118.465576
+OUTPUT_FORMAT=GTiff
+
+bmi-topography --version
+bmi-topography --help
+
+bmi-topography \
+    --dem_type=$DEM_TYPE \
+    --south=$SOUTH \
+    --north=$NORTH \
+    --west=$WEST \
+    --east=$EAST \
+    --output_format=$OUTPUT_FORMAT


### PR DESCRIPTION
This PR adds an example of using the CLI in a shell script. It also includes minor updates to the install instructions (now also with `conda`) and docs requirements.