### PR TITLE
Add ESRI ACSII and Erdas Imagine file support

### DIFF
--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Test
         run: |
-          pytest --cov=bmi-topography --cov-report=xml:./coverage.xml -vvv
+          pytest --cov=bmi_topography --cov-report=xml:./coverage.xml --cov-config=./setup.cfg -vvv
           bmi-test bmi_topography:BmiTopography --config-file=./examples/config.yaml --root-dir=./examples -vvv
 
       - name: Coveralls

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@ Changes for bmi-topography
 0.3.3 (unreleased)
 ------------------
 
-- Support ALOS World 3D 30m products
+- Support ALOS World 3D 30m products (#13)
+- Support .asc and .img files (#14)
 - Add format job to CI
 - Use CITATION.cff file
 

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ pretty: ## reformat files to make them look pretty
 	black bmi_topography tests docs examples
 
 test: ## run tests quickly with the default Python
-	pytest --disable-warnings --cov=bmi_topography --cov-report=xml:./coverage.xml -vvv
+	pytest --disable-warnings --cov=bmi_topography --cov-config=./setup.cfg --cov-report=xml:./coverage.xml -vvv
 
 bmi-test: ## run the bmi-tester
 	bmi-test bmi_topography:BmiTopography --config-file=./examples/config.yaml --root-dir=./examples -vvv

--- a/bmi_topography/cli.py
+++ b/bmi_topography/cli.py
@@ -44,14 +44,14 @@ from .topography import Topography
 )
 @click.option(
     "--output_format",
-    type=click.Choice(Topography.VALID_OUTPUT_FORMATS, case_sensitive=True),
+    type=click.Choice(Topography.VALID_OUTPUT_FORMATS.keys(), case_sensitive=True),
     default=Topography.DEFAULT["output_format"],
     help="Output file format.",
     show_default=True,
 )
 @click.option("--no_fetch", is_flag=True, help="Do not fetch data from server.")
 def main(quiet, dem_type, south, north, west, east, output_format, no_fetch):
-    """Fetch and cache Shuttle Radar Topography Mission (SRTM) elevation data"""
+    """Fetch and cache NASA SRTM and JAXA ALOS land elevation data"""
     topo = Topography(dem_type, south, north, west, east, output_format)
     if not no_fetch:
         if not quiet:

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -52,7 +52,8 @@ class Topography:
             self._file_extension = Topography.VALID_OUTPUT_FORMATS[output_format]
         else:
             raise ValueError(
-                "output_format must be one of %s." % (Topography.VALID_OUTPUT_FORMATS.keys(),)
+                "output_format must be one of %s."
+                % (Topography.VALID_OUTPUT_FORMATS.keys(),)
             )
 
         self._bbox = BoundingBox((south, west), (north, east))

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -27,7 +27,7 @@ class Topography:
     }
 
     VALID_DEM_TYPES = ("SRTMGL3", "SRTMGL1", "SRTMGL1_E", "AW3D30", "AW3D30_E")
-    VALID_OUTPUT_FORMATS = ("GTiff", "AAIGrid", "HFA")
+    VALID_OUTPUT_FORMATS = {"GTiff": "tif", "AAIGrid": "asc", "HFA": "img"}
 
     def __init__(
         self,
@@ -47,11 +47,12 @@ class Topography:
                 "dem_type must be one of %s." % (Topography.VALID_DEM_TYPES,)
             )
 
-        if output_format in Topography.VALID_OUTPUT_FORMATS:
+        if output_format in Topography.VALID_OUTPUT_FORMATS.keys():
             self._output_format = output_format
+            self._file_extension = Topography.VALID_OUTPUT_FORMATS[output_format]
         else:
             raise ValueError(
-                "output_format must be one of %s." % (Topography.VALID_OUTPUT_FORMATS,)
+                "output_format must be one of %s." % (Topography.VALID_OUTPUT_FORMATS.keys(),)
             )
 
         self._bbox = BoundingBox((south, west), (north, east))
@@ -69,6 +70,10 @@ class Topography:
     @property
     def output_format(self):
         return str(self._output_format)
+
+    @property
+    def file_extension(self):
+        return str(self._file_extension)
 
     @property
     def bbox(self):
@@ -92,12 +97,13 @@ class Topography:
         """
         fname = Path(
             self.cache_dir
-        ) / "{dem_type}_{south}_{west}_{north}_{east}.tif".format(
+        ) / "{dem_type}_{south}_{west}_{north}_{east}.{ext}".format(
             dem_type=self.dem_type,
             south=self.bbox.south,
             north=self.bbox.north,
             west=self.bbox.west,
             east=self.bbox.east,
+            ext=self.file_extension,
         )
 
         if not fname.is_file():

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -53,7 +53,7 @@ class Topography:
         else:
             raise ValueError(
                 "output_format must be one of %s."
-                % (Topography.VALID_OUTPUT_FORMATS.keys(),)
+                % [k for k in Topography.VALID_OUTPUT_FORMATS.keys()]
             )
 
         self._bbox = BoundingBox((south, west), (north, east))


### PR DESCRIPTION
This PR adds support for ESRI ACSII and Erdas Imagine files to the Topography data component.

While these formats are already supported by the OpenTopography API, I hesitated to add them to Topography because I wasn't sure if I'd have to find other libraries to read them into Python. As it turns out, the (wonderful) *xarray.openrasterio* methods loads them seamlessly.

This fixes #11.