### PR TITLE
Use an API key when requesting OpenTopography data

### DIFF
--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -42,6 +42,8 @@ jobs:
         run: make install
 
       - name: Test
+        env:
+          OPEN_TOPOGRAPHY_API_KEY: ${{ secrets.OPEN_TOPOGRAPHY_API_KEY }}
         run: |
           pytest --cov=bmi_topography --cov-report=xml:./coverage.xml --cov-config=./setup.cfg -vvv
           bmi-test bmi_topography:BmiTopography --config-file=./examples/config.yaml --root-dir=./examples -vvv

--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Test
         env:
-          OPEN_TOPOGRAPHY_API_KEY: ${{ secrets.OPEN_TOPOGRAPHY_API_KEY }}
+          OPENTOPOGRAPHY_API_KEY: ${{ secrets.OPENTOPOGRAPHY_API_KEY }}
         run: |
           pytest --cov=bmi_topography --cov-report=xml:./coverage.xml --cov-config=./setup.cfg -vvv
           bmi-test bmi_topography:BmiTopography --config-file=./examples/config.yaml --root-dir=./examples -vvv

--- a/.gitignore
+++ b/.gitignore
@@ -129,4 +129,4 @@ dmypy.json
 .pyre/
 
 # OpenTopography API key file
-.open_topography.txt
+.opentopography.txt

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# OpenTopography API key file
+.open_topography.txt

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -6,6 +6,12 @@ Project lead
 
 * Mark Piper
 
+Contributors
+------------
+
+* Eric Hutton
+* Mark Piper
+
 Acknowledgments
 ---------------
 

--- a/bmi_topography/cli.py
+++ b/bmi_topography/cli.py
@@ -51,7 +51,20 @@ from .topography import Topography
 )
 @click.option("--no_fetch", is_flag=True, help="Do not fetch data from server.")
 def main(quiet, dem_type, south, north, west, east, output_format, no_fetch):
-    """Fetch and cache NASA SRTM and JAXA ALOS land elevation data"""
+    """Fetch and cache NASA SRTM and JAXA ALOS land elevation data
+
+    To fetch some datasets you will need an OpenTopography API key.
+    You can find instructions on how to obtain one from the OpenTopography
+    website:
+
+        https://opentopography.org/blog/introducing-api-keys-access-opentopography-global-datasets
+
+    Once you have received your key, you can pass it to the *bmi-topography*
+    command in one of two ways:
+    1. As the environment variable, OPEN_TOPOGRAPHY_API_KEY.
+    2. As the contents of an *.open_topography.txt* file located either in
+       your current directory or you home directory.
+    """
     topo = Topography(dem_type, south, north, west, east, output_format)
     if not no_fetch:
         if not quiet:

--- a/bmi_topography/cli.py
+++ b/bmi_topography/cli.py
@@ -61,8 +61,8 @@ def main(quiet, dem_type, south, north, west, east, output_format, no_fetch):
 
     Once you have received your key, you can pass it to the *bmi-topography*
     command in one of two ways:
-    1. As the environment variable, OPEN_TOPOGRAPHY_API_KEY.
-    2. As the contents of an *.open_topography.txt* file located either in
+    1. As the environment variable, OPENTOPOGRAPHY_API_KEY.
+    2. As the contents of an *.opentopography.txt* file located either in
        your current directory or you home directory.
     """
     topo = Topography(dem_type, south, north, west, east, output_format)

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -11,11 +11,11 @@ from .bbox import BoundingBox
 
 def find_api_key():
     """Search for an API key."""
-    if "OPEN_TOPOGRAPHY_API_KEY" in os.environ:
-        api_key = os.environ["OPEN_TOPOGRAPHY_API_KEY"]
+    if "OPENTOPOGRAPHY_API_KEY" in os.environ:
+        api_key = os.environ["OPENTOPOGRAPHY_API_KEY"]
     else:
         api_key = read_first_of(
-            [".open_topography.txt", "~/.open_topography.txt"]
+            [".opentopography.txt", "~/.opentopography.txt"]
         ).strip()
 
     return api_key

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -23,7 +23,7 @@ def find_api_key():
 
 def read_first_of(files):
     """Read the contents of the first file encountered."""
-    contents = None
+    contents = ""
     for path in files:
         try:
             contents = open(path, "r").read()

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -15,26 +15,26 @@ def copy_environ(exclude=None):
 
 def test_find_api_key_not_found():
     """The API key is not given anywhere"""
-    env = copy_environ(exclude="OPEN_TOPOGRAPHY_API_KEY")
+    env = copy_environ(exclude="OPENTOPOGRAPHY_API_KEY")
     with mock.patch.dict(os.environ, env, clear=True):
         assert find_api_key() == ""
 
 
-@mock.patch.dict(os.environ, {"OPEN_TOPOGRAPHY_API_KEY": "foo"})
+@mock.patch.dict(os.environ, {"OPENTOPOGRAPHY_API_KEY": "foo"})
 def test_find_api_key_env(tmpdir):
     """The API key is an environment variable"""
     with tmpdir.as_cwd():
-        with open(".open_topography.txt", "w") as fp:
+        with open(".opentopography.txt", "w") as fp:
             fp.write("bar")
     assert find_api_key() == "foo"
 
 
-@mock.patch.dict(os.environ, {"OPEN_TOPOGRAPHY_API_KEY": "foo"})
+@mock.patch.dict(os.environ, {"OPENTOPOGRAPHY_API_KEY": "foo"})
 def test_find_api_key_from_file(tmpdir):
     """The API key is in a file"""
-    env = copy_environ(exclude="OPEN_TOPOGRAPHY_API_KEY")
+    env = copy_environ(exclude="OPENTOPOGRAPHY_API_KEY")
     with tmpdir.as_cwd():
-        with open(".open_topography.txt", "w") as fp:
+        with open(".opentopography.txt", "w") as fp:
             fp.write("bar")
 
         with mock.patch.dict(os.environ, env, clear=True):

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -1,0 +1,58 @@
+import os
+from unittest import mock
+
+from bmi_topography.topography import find_api_key, read_first_of
+
+
+def copy_environ(exclude=None):
+    if exclude is None:
+        exclude = {}
+    elif isinstance(exclude, str):
+        exclude = {exclude}
+
+    return {key: value for key, value in os.environ.items() if key not in exclude}
+
+
+def test_find_api_key_not_found():
+    """The API key is not given anywhere"""
+    env = copy_environ(exclude="OPEN_TOPOGRAPHY_API_KEY")
+    with mock.patch.dict(os.environ, env, clear=True):
+        assert find_api_key() == ""
+
+
+@mock.patch.dict(os.environ, {"OPEN_TOPOGRAPHY_API_KEY": "foo"})
+def test_find_api_key_env(tmpdir):
+    """The API key is an environment variable"""
+    with tmpdir.as_cwd():
+        with open(".open_topography.txt", "w") as fp:
+            fp.write("bar")
+    assert find_api_key() == "foo"
+
+
+@mock.patch.dict(os.environ, {"OPEN_TOPOGRAPHY_API_KEY": "foo"})
+def test_find_api_key_from_file(tmpdir):
+    """The API key is in a file"""
+    env = copy_environ(exclude="OPEN_TOPOGRAPHY_API_KEY")
+    with tmpdir.as_cwd():
+        with open(".open_topography.txt", "w") as fp:
+            fp.write("bar")
+
+        with mock.patch.dict(os.environ, env, clear=True):
+            assert find_api_key() == "bar"
+
+
+def test_read_first_missing(tmpdir):
+    with tmpdir.as_cwd():
+        assert read_first_of(["foo.txt"]) == ""
+        assert read_first_of([]) == ""
+
+
+def test_read_first_file(tmpdir):
+    with tmpdir.as_cwd():
+        with open("foo.txt", "w") as fp:
+            fp.write("foo")
+        with open("bar.txt", "w") as fp:
+            fp.write("bar")
+
+        assert read_first_of(["foo.txt", "bar.txt"]) == "foo"
+        assert read_first_of(["bar.txt", "foo.txt"]) == "bar"


### PR DESCRIPTION
@mdpiper for your consideration...

This pull request adds *api_key* as a keyword to *Topography* so that a user can use an OpenTopography API key to fetch data sets. If not passed explicitly, *Topography* will first look to the contents of an environment variable (*OPEN_TOPOGRAPHY_API_KEY*), and then to the contents of an *.open_topography.txt* file (first in the current directory and then in the user's home directory).

This is meant to address #23.