### PR TITLE
Use new black synatx

### DIFF
--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -76,7 +76,8 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: psf/black@stable
         with:
-          args: ". --check"
+          options: "--check --verbose --diff"
+          src: "bmi_topography tests examples docs"
 
   docs:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,6 @@ lint: ## check style with flake8
 	flake8 bmi_topography tests docs examples
 
 pretty: ## reformat files to make them look pretty
-	find bmi_topography tests docs examples -name '*.py' | xargs isort
 	black bmi_topography tests docs examples
 
 test: ## run tests quickly with the default Python


### PR DESCRIPTION
This PR updates the use of the *black* formatter to use its new syntax. This fixes #30.