### PR TITLE
Provide a helpful message when missing API key

### DIFF
--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -34,6 +34,14 @@ def read_first_of(files):
     return contents
 
 
+class APIKeyError(Exception):
+    def __init__(self):
+        self.message = "This dataset requires an API Key for access."
+
+    def __str__(self):
+        return self.message
+
+
 class Topography:
 
     """Fetch and cache NASA SRTM land elevation data."""
@@ -153,7 +161,10 @@ class Topography:
                 params["API_Key"] = self._api_key
 
             response = requests.get(Topography.data_url(), params=params, stream=True)
-            response.raise_for_status()
+            if response.status_code == 401:
+                raise APIKeyError()
+            else:
+                response.raise_for_status()
 
             with fname.open("wb") as fp:
                 for chunk in response.iter_content(chunk_size=None):

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -34,14 +34,6 @@ def read_first_of(files):
     return contents
 
 
-class APIKeyError(Exception):
-    def __init__(self):
-        self.message = "This dataset requires an API Key for access."
-
-    def __str__(self):
-        return self.message
-
-
 class Topography:
 
     """Fetch and cache NASA SRTM land elevation data."""
@@ -162,9 +154,8 @@ class Topography:
 
             response = requests.get(Topography.data_url(), params=params, stream=True)
             if response.status_code == 401:
-                raise APIKeyError()
-            else:
-                response.raise_for_status()
+                response.reason = "This dataset requires an API Key for access"
+            response.raise_for_status()
 
             with fname.open("wb") as fp:
                 for chunk in response.iter_content(chunk_size=None):


### PR DESCRIPTION
This PR adds text to the exception raised when an API key is needed to access a dataset on OpenTopography. This fixes #29.