### PR TITLE
Document use of API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,26 @@ Then build and install *bmi-topography* from source with
 make install
 ```
 
+## API key
+
+To better understand usage,
+OpenTopography [requires an API key][ot-api-key] to access datasets they host.
+Getting an API key is easy, and it's free;
+just follow the instructions in the link above.
+
+Once you have an API key,
+there are three ways to use it with *bmi-topography*:
+
+1. *parameter*: Pass the API key as a string through the `API_key` parameter.
+2. *environment variable*: In the shell, set the `OPENTOPOGRAPHY_API_KEY` environment variable to the API key value.
+3. *dot file*: Put the API key in the file `.opentopography.txt` in the current directory or in your home directory.
+
+If you attempt to use *bmi-topography* to access an OpenTopography dataset without an API key,
+you'll get a error like this: 
+```
+requests.exceptions.HTTPError: 401 Client Error: This dataset requires an API Key for access.
+```
+
 ## Examples
 
 A brief example of using the *bmi-topography* API is given in the following steps.
@@ -158,6 +178,7 @@ is available at https://bmi-topography.readthedocs.io.
 [bmi-topo-repo]: https://github.com/csdms/bmi-topography
 [conda-env]: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html
 [ot]: https://opentopography.org/
+[ot-api-key]: https://opentopography.org/blog/introducing-api-keys-access-opentopography-global-datasets
 [ot-rest]: https://portal.opentopography.org/apidocs/
 [srtm]: https://www2.jpl.nasa.gov/srtm/
 [xarray]: http://xarray.pydata.org/en/stable/

--- a/bmi_topography/cli.py
+++ b/bmi_topography/cli.py
@@ -53,17 +53,16 @@ from .topography import Topography
 def main(quiet, dem_type, south, north, west, east, output_format, no_fetch):
     """Fetch and cache NASA SRTM and JAXA ALOS land elevation data
 
-    To fetch some datasets you will need an OpenTopography API key.
-    You can find instructions on how to obtain one from the OpenTopography
-    website:
+    Some datasets require an OpenTopography API key. You can find instructions
+    on how to obtain one from the OpenTopography website:
 
         https://opentopography.org/blog/introducing-api-keys-access-opentopography-global-datasets
 
-    Once you have received your key, you can pass it to the *bmi-topography*
-    command in one of two ways:
-    1. As the environment variable, OPENTOPOGRAPHY_API_KEY.
-    2. As the contents of an *.opentopography.txt* file located either in
-       your current directory or you home directory.
+    Once you have a key, you can pass it to the bmi-topography
+    command in one of two ways: 1) through the environment variable
+    OPENTOPOGRAPHY_API_KEY, or 2) as the contents of the file
+    ".opentopography.txt" located either in your current directory or your home
+    directory.
     """
     topo = Topography(dem_type, south, north, west, east, output_format)
     if not no_fetch:

--- a/bmi_topography/cli.py
+++ b/bmi_topography/cli.py
@@ -49,8 +49,14 @@ from .topography import Topography
     help="Output file format.",
     show_default=True,
 )
+@click.option(
+    "--api_key",
+    type=str,
+    help="OpenTopography API key.",
+    show_default=True,
+)
 @click.option("--no_fetch", is_flag=True, help="Do not fetch data from server.")
-def main(quiet, dem_type, south, north, west, east, output_format, no_fetch):
+def main(quiet, dem_type, south, north, west, east, output_format, api_key, no_fetch):
     """Fetch and cache NASA SRTM and JAXA ALOS land elevation data
 
     Some datasets require an OpenTopography API key. You can find instructions

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -1,4 +1,4 @@
-"""Base class to access SRTM elevation data"""
+"""Base class to access elevation data"""
 import os
 import urllib
 from pathlib import Path

--- a/docs/source/README.rst
+++ b/docs/source/README.rst
@@ -71,6 +71,31 @@ Then build and install *bmi-topography* from source with
 
    make install
 
+API key
+-------
+
+To better understand usage, OpenTopography `requires an API
+key <https://opentopography.org/blog/introducing-api-keys-access-opentopography-global-datasets>`__
+to access datasets they host. Getting an API key is easy, and it’s free;
+just follow the instructions in the link above.
+
+Once you have an API key, there are three ways to use it with
+*bmi-topography*:
+
+1. *parameter*: Pass the API key as a string through the ``API_key``
+   parameter.
+2. *environment variable*: In the shell, set the
+   ``OPENTOPOGRAPHY_API_KEY`` environment variable to the API key value.
+3. *dot file*: Put the API key in the file ``.opentopography.txt`` in
+   the current directory or in your home directory.
+
+If you attempt to use *bmi-topography* to access an OpenTopography
+dataset without an API key, you’ll get a error like this:
+
+::
+
+   requests.exceptions.HTTPError: 401 Client Error: This dataset requires an API Key for access.
+
 Examples
 --------
 

--- a/docs/source/_templates/links.html
+++ b/docs/source/_templates/links.html
@@ -1,7 +1,8 @@
 <h3>Useful Links</h3>
 <ul>
   <li><a href="https://github.com/csdms/bmi-topography/">bmi-topography @ GitHub</a></li>
-  <li><a href="https://github.com/csdms/bmi-topography/issues">Issue Tracker</a></li>
+  <li><a href="https://opentopography.org/">OpenTopography homepage</a></li>
+  <li><a href="https://csdms.colorado.edu">CSDMS homepage</a></li>
   <li><a href="https://csdms.colorado.edu/wiki/Workbench">CSDMS Workbench</a></li>
-  <li><a href="https://csdms.colorado.edu">CSDMS Homepage</a></li>
+  <li><a href="https://bmi.readthedocs.io">BMI documentation</a></li>
 </ul>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ master_doc = "index"
 # -- Project information -----------------------------------------------------
 
 project = "bmi-topography"
-author = "Mark Piper"
+author = "Community Surface Dynamics Modeling System"
 version = pkg_resources.get_distribution("bmi_topography").version
 release = version
 this_year = datetime.date.today().year

--- a/examples/.opentopography.txt
+++ b/examples/.opentopography.txt
@@ -1,0 +1,1 @@
+demoapikeyot2022


### PR DESCRIPTION
This PR documents how to obtain an API key from OpenTopography and use it with *bmi-topography*. This fixes #27.