### PR TITLE
Use a demo API key if a user key can't be found

### DIFF
--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -1,6 +1,7 @@
 """Base class to access elevation data"""
 import os
 import urllib
+import warnings
 from pathlib import Path
 
 import requests
@@ -9,7 +10,7 @@ import xarray as xr
 from .bbox import BoundingBox
 
 
-def find_api_key():
+def find_user_api_key():
     """Search for an API key."""
     if "OPENTOPOGRAPHY_API_KEY" in os.environ:
         api_key = os.environ["OPENTOPOGRAPHY_API_KEY"]
@@ -19,6 +20,15 @@ def find_api_key():
         ).strip()
 
     return api_key
+
+
+def use_demo_key():
+    warnings.warn(
+        "You are using a demo key to fetch data from OpenTopography, functionality "
+        "will be limited. See https://bmi-topography.readthedocs.io/en/latest/#api-key "
+        "for more information."
+    )
+    return "<the-demo-key>"
 
 
 def read_first_of(files):
@@ -67,7 +77,7 @@ class Topography:
         api_key=None,
     ):
         if api_key is None:
-            self._api_key = find_api_key()
+            self._api_key = find_user_api_key() or use_demo_key()
         else:
             self._api_key = api_key
 

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -28,7 +28,7 @@ def use_demo_key():
         "will be limited. See https://bmi-topography.readthedocs.io/en/latest/#api-key "
         "for more information."
     )
-    return "<the-demo-key>"
+    return "demoapikeyot2022"
 
 
 def read_first_of(files):

--- a/examples/.opentopography.txt
+++ b/examples/.opentopography.txt
@@ -1,1 +1,0 @@
-demoapikeyot2022

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -1,7 +1,9 @@
 import os
 from unittest import mock
 
-from bmi_topography.topography import find_user_api_key, read_first_of
+import pytest
+
+from bmi_topography.topography import find_user_api_key, read_first_of, use_demo_key
 
 
 def copy_environ(exclude=None):
@@ -56,3 +58,14 @@ def test_read_first_file(tmpdir):
 
         assert read_first_of(["foo.txt", "bar.txt"]) == "foo"
         assert read_first_of(["bar.txt", "foo.txt"]) == "bar"
+
+
+def test_use_demo_key_is_a_string():
+    demo_key = use_demo_key()
+    assert isinstance(demo_key, str)
+    assert len(demo_key) > 0
+
+
+def test_use_demo_key_issues_warning():
+    with pytest.warns(UserWarning):
+        use_demo_key()

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -1,7 +1,7 @@
 import os
 from unittest import mock
 
-from bmi_topography.topography import find_api_key, read_first_of
+from bmi_topography.topography import find_user_api_key, read_first_of
 
 
 def copy_environ(exclude=None):
@@ -13,24 +13,24 @@ def copy_environ(exclude=None):
     return {key: value for key, value in os.environ.items() if key not in exclude}
 
 
-def test_find_api_key_not_found():
+def test_find_user_api_key_not_found():
     """The API key is not given anywhere"""
     env = copy_environ(exclude="OPENTOPOGRAPHY_API_KEY")
     with mock.patch.dict(os.environ, env, clear=True):
-        assert find_api_key() == ""
+        assert find_user_api_key() == ""
 
 
 @mock.patch.dict(os.environ, {"OPENTOPOGRAPHY_API_KEY": "foo"})
-def test_find_api_key_env(tmpdir):
+def test_find_user_api_key_env(tmpdir):
     """The API key is an environment variable"""
     with tmpdir.as_cwd():
         with open(".opentopography.txt", "w") as fp:
             fp.write("bar")
-    assert find_api_key() == "foo"
+    assert find_user_api_key() == "foo"
 
 
 @mock.patch.dict(os.environ, {"OPENTOPOGRAPHY_API_KEY": "foo"})
-def test_find_api_key_from_file(tmpdir):
+def test_find_user_api_key_from_file(tmpdir):
     """The API key is in a file"""
     env = copy_environ(exclude="OPENTOPOGRAPHY_API_KEY")
     with tmpdir.as_cwd():
@@ -38,7 +38,7 @@ def test_find_api_key_from_file(tmpdir):
             fp.write("bar")
 
         with mock.patch.dict(os.environ, env, clear=True):
-            assert find_api_key() == "bar"
+            assert find_user_api_key() == "bar"
 
 
 def test_read_first_missing(tmpdir):


### PR DESCRIPTION
I've added a tiny bit of code so that if Topography can't find a user API key, it will use the OpenTopography demo key. I haven't actually added the demo key yet but will do so if this is what we want to do.