### PR TITLE
Use dashes in command line options

### DIFF
--- a/bmi_topography/cli.py
+++ b/bmi_topography/cli.py
@@ -8,7 +8,7 @@ from .topography import Topography
 @click.version_option()
 @click.option("-q", "--quiet", is_flag=True, help="Enables quiet mode.")
 @click.option(
-    "--dem_type",
+    "--dem-type",
     type=click.Choice(Topography.VALID_DEM_TYPES, case_sensitive=True),
     default=Topography.DEFAULT["dem_type"],
     help="The global raster dataset.",
@@ -43,19 +43,19 @@ from .topography import Topography
     show_default=True,
 )
 @click.option(
-    "--output_format",
+    "--output-format",
     type=click.Choice(Topography.VALID_OUTPUT_FORMATS.keys(), case_sensitive=True),
     default=Topography.DEFAULT["output_format"],
     help="Output file format.",
     show_default=True,
 )
 @click.option(
-    "--api_key",
+    "--api-key",
     type=str,
     help="OpenTopography API key.",
     show_default=True,
 )
-@click.option("--no_fetch", is_flag=True, help="Do not fetch data from server.")
+@click.option("--no-fetch", is_flag=True, help="Do not fetch data from server.")
 def main(quiet, dem_type, south, north, west, east, output_format, api_key, no_fetch):
     """Fetch and cache NASA SRTM and JAXA ALOS land elevation data
 

--- a/bmi_topography/cli.py
+++ b/bmi_topography/cli.py
@@ -74,10 +74,11 @@ def main(quiet, dem_type, south, north, west, east, output_format, api_key, no_f
     if not no_fetch:
         if not quiet:
             click.secho("Fetching data...", fg="yellow", err=True)
-        topo.fetch()
+        path_to_dem = topo.fetch()
         if not quiet:
             click.secho(
                 "File downloaded to {}".format(getattr(topo, "cache_dir")),
                 fg="green",
                 err=True,
             )
+        print(path_to_dem)

--- a/bmi_topography/cli.py
+++ b/bmi_topography/cli.py
@@ -73,9 +73,11 @@ def main(quiet, dem_type, south, north, west, east, output_format, api_key, no_f
     topo = Topography(dem_type, south, north, west, east, output_format)
     if not no_fetch:
         if not quiet:
-            click.secho("Fetching data...", fg="yellow")
+            click.secho("Fetching data...", fg="yellow", err=True)
         topo.fetch()
         if not quiet:
             click.secho(
-                "File downloaded to {}".format(getattr(topo, "cache_dir")), fg="green"
+                "File downloaded to {}".format(getattr(topo, "cache_dir")),
+                fg="green",
+                err=True,
             )

--- a/examples/bmi-topography_ex.sh
+++ b/examples/bmi-topography_ex.sh
@@ -12,9 +12,9 @@ bmi-topography --version
 bmi-topography --help
 
 bmi-topography \
-    --dem_type=$DEM_TYPE \
+    --dem-type=$DEM_TYPE \
     --south=$SOUTH \
     --north=$NORTH \
     --west=$WEST \
     --east=$EAST \
-    --output_format=$OUTPUT_FORMAT
+    --output-format=$OUTPUT_FORMAT

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,6 @@
 """Test bmi-topography command-line interface"""
+import pathlib
+
 from click.testing import CliRunner
 
 from bmi_topography.cli import main
@@ -20,7 +22,8 @@ def test_version():
 
 def test_defaults():
     runner = CliRunner()
-    result = runner.invoke(main)
+    result = runner.invoke(main, ["--quiet"])
+    assert pathlib.Path(result.output.strip()).is_file()
     assert result.exit_code == 0
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,6 +27,14 @@ def test_defaults():
     assert result.exit_code == 0
 
 
+def test_quiet():
+    runner = CliRunner()
+    quiet_lines = runner.invoke(main, ["--quiet"]).output.splitlines()
+    verbose_lines = runner.invoke(main).output.splitlines()
+
+    assert len(verbose_lines) > len(quiet_lines)
+
+
 def test_demtype_valid():
     runner = CliRunner()
     result = runner.invoke(main, ["--dem-type=SRTMGL1", "--no-fetch"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,25 +26,25 @@ def test_defaults():
 
 def test_demtype_valid():
     runner = CliRunner()
-    result = runner.invoke(main, ["--dem_type=SRTMGL1", "--no_fetch"])
+    result = runner.invoke(main, ["--dem-type=SRTMGL1", "--no-fetch"])
     assert result.exit_code == 0
 
 
 def test_demtype_invalid():
     runner = CliRunner()
-    result = runner.invoke(main, ["--dem_type=foobar"])
+    result = runner.invoke(main, ["--dem-type=foobar"])
     assert result.exit_code != 0
 
 
 def test_demtype_is_case_sensitive():
     runner = CliRunner()
-    result = runner.invoke(main, ["--dem_type=srtmgl1"])
+    result = runner.invoke(main, ["--dem-type=srtmgl1"])
     assert result.exit_code != 0
 
 
 def test_south_inrange():
     runner = CliRunner()
-    result = runner.invoke(main, ["--south=-90.0", "--no_fetch"])
+    result = runner.invoke(main, ["--south=-90.0", "--no-fetch"])
     assert result.exit_code == 0
 
 
@@ -56,7 +56,7 @@ def test_south_outrange():
 
 def test_north_inrange():
     runner = CliRunner()
-    result = runner.invoke(main, ["--north=90.0", "--no_fetch"])
+    result = runner.invoke(main, ["--north=90.0", "--no-fetch"])
     assert result.exit_code == 0
 
 
@@ -68,7 +68,7 @@ def test_north_outrange():
 
 def test_west_inrange():
     runner = CliRunner()
-    result = runner.invoke(main, ["--west=-180.0", "--no_fetch"])
+    result = runner.invoke(main, ["--west=-180.0", "--no-fetch"])
     assert result.exit_code == 0
 
 
@@ -80,7 +80,7 @@ def test_west_outrange():
 
 def test_east_inrange():
     runner = CliRunner()
-    result = runner.invoke(main, ["--east=180.0", "--no_fetch"])
+    result = runner.invoke(main, ["--east=180.0", "--no-fetch"])
     assert result.exit_code == 0
 
 
@@ -92,17 +92,17 @@ def test_east_outrange():
 
 def test_output_format_valid():
     runner = CliRunner()
-    result = runner.invoke(main, ["--output_format=GTiff", "--no_fetch"])
+    result = runner.invoke(main, ["--output-format=GTiff", "--no-fetch"])
     assert result.exit_code == 0
 
 
 def test_output_format_invalid():
     runner = CliRunner()
-    result = runner.invoke(main, ["--output_format=foobar"])
+    result = runner.invoke(main, ["--output-format=foobar"])
     assert result.exit_code != 0
 
 
 def test_output_format_is_case_sensitive():
     runner = CliRunner()
-    result = runner.invoke(main, ["--output_format=gtiff"])
+    result = runner.invoke(main, ["--output-format=gtiff"])
     assert result.exit_code != 0


### PR DESCRIPTION
This pull request replaces underscores in *bmi-topography* command line options with dashes.

Resolves #35.