### PR TITLE
Create test matrix of datasets and file types

### DIFF
--- a/tests/test_topography.py
+++ b/tests/test_topography.py
@@ -1,6 +1,5 @@
 """Test Topography class"""
 import os
-import numpy
 import pytest
 
 from bmi_topography import Topography
@@ -75,7 +74,9 @@ def test_cached_data(tmpdir, shared_datadir):
 
 @pytest.mark.skipif("NO_FETCH" in os.environ, reason="NO_FETCH is set")
 @pytest.mark.parametrize("dem_type", Topography.VALID_DEM_TYPES)
-@pytest.mark.parametrize("output_format,file_type", Topography.VALID_OUTPUT_FORMATS.items())
+@pytest.mark.parametrize(
+    "output_format,file_type", Topography.VALID_OUTPUT_FORMATS.items()
+)
 def test_fetch(tmpdir, dem_type, output_format, file_type):
     with tmpdir.as_cwd():
         topo = Topography(

--- a/tests/test_topography.py
+++ b/tests/test_topography.py
@@ -73,11 +73,12 @@ def test_cached_data(tmpdir, shared_datadir):
 
 
 @pytest.mark.parametrize("dem_type", Topography.VALID_DEM_TYPES)
-def test_fetch(tmpdir, dem_type):
+@pytest.mark.parametrize("output_format,file_type", Topography.VALID_OUTPUT_FORMATS.items())
+def test_fetch(tmpdir, dem_type, output_format, file_type):
     with tmpdir.as_cwd():
         topo = Topography(
             dem_type=dem_type,
-            output_format=Topography.DEFAULT["output_format"],
+            output_format=output_format,
             south=CENTER_LAT - WIDTH,
             west=CENTER_LON - WIDTH,
             north=CENTER_LAT + WIDTH,
@@ -85,7 +86,7 @@ def test_fetch(tmpdir, dem_type):
             cache_dir=".",
         )
         topo.fetch()
-        assert len(tmpdir.listdir(fil=lambda f: f.ext == ".tif")) == 1
+        assert len(tmpdir.listdir(fil=lambda f: f.ext == "." + file_type)) == 1
 
 
 def test_load(tmpdir, shared_datadir):

--- a/tests/test_topography.py
+++ b/tests/test_topography.py
@@ -1,4 +1,5 @@
 """Test Topography class"""
+import os
 import numpy
 import pytest
 
@@ -72,6 +73,7 @@ def test_cached_data(tmpdir, shared_datadir):
         assert len(tmpdir.listdir(fil=lambda f: f.ext == ".tif")) == 0
 
 
+@pytest.mark.skipif("NO_FETCH" in os.environ, reason="NO_FETCH is set")
 @pytest.mark.parametrize("dem_type", Topography.VALID_DEM_TYPES)
 @pytest.mark.parametrize("output_format,file_type", Topography.VALID_OUTPUT_FORMATS.items())
 def test_fetch(tmpdir, dem_type, output_format, file_type):

--- a/tests/test_topography.py
+++ b/tests/test_topography.py
@@ -5,6 +5,9 @@ import pytest
 from bmi_topography import Topography
 
 API_URL = "https://portal.opentopography.org/API/globaldem"
+CENTER_LAT = 40.0
+CENTER_LON = -105.0
+WIDTH = 0.01
 
 
 def test_data_url():
@@ -69,17 +72,16 @@ def test_cached_data(tmpdir, shared_datadir):
         assert len(tmpdir.listdir(fil=lambda f: f.ext == ".tif")) == 0
 
 
-def test_fetch(tmpdir):
-    new_south = numpy.mean([Topography.DEFAULT["south"], Topography.DEFAULT["north"]])
-    new_west = numpy.mean([Topography.DEFAULT["west"], Topography.DEFAULT["east"]])
+@pytest.mark.parametrize("dem_type", Topography.VALID_DEM_TYPES)
+def test_fetch(tmpdir, dem_type):
     with tmpdir.as_cwd():
         topo = Topography(
-            dem_type=Topography.DEFAULT["dem_type"],
+            dem_type=dem_type,
             output_format=Topography.DEFAULT["output_format"],
-            south=new_south,
-            west=new_west,
-            north=Topography.DEFAULT["north"],
-            east=Topography.DEFAULT["east"],
+            south=CENTER_LAT - WIDTH,
+            west=CENTER_LON - WIDTH,
+            north=CENTER_LAT + WIDTH,
+            east=CENTER_LON + WIDTH,
             cache_dir=".",
         )
         topo.fetch()


### PR DESCRIPTION
This PR sets up a matrix of tests for each dataset and each output format in the *test_fetch* test function.

It also includes a way to skip calling this function--hitting the OpenTopography server too many times appears to invalidate an API key.

This fixes #37. As a part of this solution, this also fixes #26.