### PR TITLE
Support all OpenTopography global datasets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Changes for bmi-topography
 0.7 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Optionally disable fetch test
 
 
 0.6 (2022-02-17)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Changes for bmi-topography
 0.7 (unreleased)
 ----------------
 
-- Optionally disable fetch test
+- Create test matrix of datasets and file types (#38)
 
 
 0.6 (2022-02-17)

--- a/README.md
+++ b/README.md
@@ -7,19 +7,20 @@
 # bmi-topography
 
 *bmi-topography* is a Python library for fetching and caching
-land elevation data from the
-NASA [Shuttle Radar Topography Mission][srtm] (SRTM)
-and the
-JAXA [Advanced Land Observing Satellite][alos] (ALOS)
+land elevation data
 using the [OpenTopography][ot] [REST API][ot-rest].
 
 The *bmi-topography* library provides access to the following global raster datasets:
 
-* SRTM GL3 (90m)
-* SRTM GL1 (30m)
-* SRTM GL1 (30m, Ellipsoidal)
-* ALOS World 3D (30m)
-* ALOS World 3D (30m, Ellipsoidal) 
+* SRTMGL3 (SRTM GL3 90m)
+* SRTMGL1 (SRTM GL1 30m)
+* SRTMGL1_E (SRTM GL1 Ellipsoidal 30m)
+* AW3D30 (ALOS World 3D 30m)
+* AW3D30_E (ALOS World 3D Ellipsoidal, 30m)
+* SRTM15Plus (Global Bathymetry SRTM15+ V2.1)
+* NASADEM (NASADEM Global DEM)
+* COP30 (Copernicus Global DSM 30m)
+* COP90 (Copernicus Global DSM 90m)
 
 The library includes an API and a CLI that accept
 the dataset type,
@@ -68,7 +69,7 @@ make install
 
 To better understand usage,
 OpenTopography [requires an API key][ot-api-key] to access datasets they host.
-Getting an API key is easy, and it's free;
+Getting an API key is easy, and it's free:
 just follow the instructions in the link above.
 
 Once you have an API key,
@@ -172,7 +173,6 @@ is available at https://bmi-topography.readthedocs.io.
 
 <!-- Links (by alpha) -->
 
-[alos]: https://www.eorc.jaxa.jp/ALOS/en/aw3d30/index.htm
 [bmi]: https://bmi.readthedocs.io
 [bmi-topo-examples]: https://github.com/csdms/bmi-topography/tree/main/examples
 [bmi-topo-repo]: https://github.com/csdms/bmi-topography
@@ -180,7 +180,6 @@ is available at https://bmi-topography.readthedocs.io.
 [ot]: https://opentopography.org/
 [ot-api-key]: https://opentopography.org/blog/introducing-api-keys-access-opentopography-global-datasets
 [ot-rest]: https://portal.opentopography.org/apidocs/
-[srtm]: https://www2.jpl.nasa.gov/srtm/
 [xarray]: http://xarray.pydata.org/en/stable/
 [xarray-da]: http://xarray.pydata.org/en/stable/api.html#dataarray
 [xarray-or]: http://xarray.pydata.org/en/stable/generated/xarray.open_rasterio.html#xarray.open_rasterio

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -62,7 +62,17 @@ class Topography:
         "cache_dir": "~/.bmi_topography",
     }
 
-    VALID_DEM_TYPES = ("SRTMGL3", "SRTMGL1", "SRTMGL1_E", "AW3D30", "AW3D30_E")
+    VALID_DEM_TYPES = (
+        "SRTMGL3",
+        "SRTMGL1",
+        "SRTMGL1_E",
+        "AW3D30",
+        "AW3D30_E",
+        "SRTM15Plus",
+        "NASADEM",
+        "COP30",
+        "COP90",
+    )
     VALID_OUTPUT_FORMATS = {"GTiff": "tif", "AAIGrid": "asc", "HFA": "img"}
 
     def __init__(

--- a/docs/source/README.rst
+++ b/docs/source/README.rst
@@ -5,21 +5,22 @@ bmi-topography
 ==============
 
 *bmi-topography* is a Python library for fetching and caching land
-elevation data from the NASA `Shuttle Radar Topography
-Mission <https://www2.jpl.nasa.gov/srtm/>`__ (SRTM) and the JAXA
-`Advanced Land Observing
-Satellite <https://www.eorc.jaxa.jp/ALOS/en/aw3d30/index.htm>`__ (ALOS)
-using the `OpenTopography <https://opentopography.org/>`__ `REST
+elevation data using the
+`OpenTopography <https://opentopography.org/>`__ `REST
 API <https://portal.opentopography.org/apidocs/>`__.
 
 The *bmi-topography* library provides access to the following global
 raster datasets:
 
--  SRTM GL3 (90m)
--  SRTM GL1 (30m)
--  SRTM GL1 (30m, Ellipsoidal)
--  ALOS World 3D (30m)
--  ALOS World 3D (30m, Ellipsoidal)
+-  SRTMGL3 (SRTM GL3 90m)
+-  SRTMGL1 (SRTM GL1 30m)
+-  SRTMGL1_E (SRTM GL1 Ellipsoidal 30m)
+-  AW3D30 (ALOS World 3D 30m)
+-  AW3D30_E (ALOS World 3D Ellipsoidal, 30m)
+-  SRTM15Plus (Global Bathymetry SRTM15+ V2.1)
+-  NASADEM (NASADEM Global DEM)
+-  COP30 (Copernicus Global DSM 30m)
+-  COP90 (Copernicus Global DSM 90m)
 
 The library includes an API and a CLI that accept the dataset type, a
 latitude-longitude bounding box, and the output file format. Data are
@@ -76,7 +77,7 @@ API key
 
 To better understand usage, OpenTopography `requires an API
 key <https://opentopography.org/blog/introducing-api-keys-access-opentopography-global-datasets>`__
-to access datasets they host. Getting an API key is easy, and it’s free;
+to access datasets they host. Getting an API key is easy, and it’s free:
 just follow the instructions in the link above.
 
 Once you have an API key, there are three ways to use it with

--- a/docs/source/_templates/sidebarintro.html
+++ b/docs/source/_templates/sidebarintro.html
@@ -1,9 +1,6 @@
 <h3>About bmi-topography</h3>
 <p>
   Fetch and cache land elevation data
-  from the
-  NASA Shuttle Radar Topography Mission (SRTM)
-  or the
-  JAXA Advanced Land Observing Satellite (ALOS)
+  from OpenTopography
   through an API, CLI, or BMI.
 </p>

--- a/docs/source/_templates/sidebarintro.html
+++ b/docs/source/_templates/sidebarintro.html
@@ -2,5 +2,5 @@
 <p>
   Fetch and cache land elevation data
   from OpenTopography
-  through an API, CLI, or BMI.
+  with an API, CLI, or BMI.
 </p>

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,10 +3,10 @@ name = bmi-topography
 version = 0.7.dev0
 author = Mark Piper
 author_email = mark.piper@colorado.edu
-description = Fetch and cache NASA SRTM and JAXA ALOS land elevation data
+description = Fetch and cache land elevation data from OpenTopography
 long_description = file: README.md, CHANGES.md, CONTRIBUTING.md, CREDITS.md, CITATION.cff, LICENSE.md
 long_description_content_type = text/markdown
-keywords = bmi, srtm, alos, topography, elevation, dem, data
+keywords = bmi, srtm, alos, nasadem, copernicus, topography, elevation, dem, data
 license = MIT License
 url = https://github.com/csdms/bmi-topography
 classifiers =
@@ -15,6 +15,7 @@ classifiers =
     Operating System :: OS Independent
     Intended Audience :: Developers
     Intended Audience :: Science/Research
+    Intended Audience :: Education
 
 [options]
 include_package_data = True

--- a/tests/test_topography.py
+++ b/tests/test_topography.py
@@ -1,4 +1,5 @@
 """Test Topography class"""
+import os
 import numpy
 import pytest
 
@@ -69,6 +70,7 @@ def test_cached_data(tmpdir, shared_datadir):
         assert len(tmpdir.listdir(fil=lambda f: f.ext == ".tif")) == 0
 
 
+@pytest.mark.skipif("NO_FETCH" in os.environ, reason="NO_FETCH is set")
 def test_fetch(tmpdir):
     new_south = numpy.mean([Topography.DEFAULT["south"], Topography.DEFAULT["north"]])
     new_west = numpy.mean([Topography.DEFAULT["west"], Topography.DEFAULT["east"]])


### PR DESCRIPTION
This PR adds support to *bmi-topography* for the remaining OT global datasets:

* SRTM15Plus (Global Bathymetry SRTM15+ V2.1)
* NASADEM (NASADEM Global DEM)
* COP30 (Copernicus Global DSM 30m)
* COP90 (Copernicus Global DSM 90m)

This fixes #20.