### PR TITLE
Provide a better reason for 401 errors

### DIFF
--- a/bmi_topography/api_key.py
+++ b/bmi_topography/api_key.py
@@ -79,11 +79,21 @@ class ApiKey:
     def __str__(self):
         return self.api_key
 
+    def __len__(self):
+        return len(self.api_key)
+
+    def __eq__(self, val):
+        try:
+            return self.api_key == val.api_key
+        except AttributeError:
+            return str(self) == val
+
 
 def find_first_of(files):
     found = None
     for path in (Path(name) for name in files):
         if path.expanduser().is_file():
             found = path.expanduser()
+            break
     return found
 

--- a/bmi_topography/api_key.py
+++ b/bmi_topography/api_key.py
@@ -3,10 +3,38 @@ import warnings
 from functools import partial
 from pathlib import Path
 
-from .errors import BadKeyError, MissingKeyError
+from .errors import BadApiKeySource, BadKeyError, MissingKeyError
 
 
 class ApiKey:
+
+    """Store an API key to use when fetching topography data from OpenTopography.
+
+    Parameters
+    ----------
+    api_key : str
+        An API key as a (non-empty) string.
+    source : str, optional
+        A string that indicates where the key came from. Possible
+        values are: *user*, *env*, *file*, and *demo*.
+
+    Raises
+    ------
+    BadKeyError
+        The provided API key is invalid.
+    MissingKeyError
+        A key could not be found in the usual places.
+    BadApiKeySource
+        An invalid source was provided.
+
+    Examples
+    --------
+    >>> from bmi_topography.api_key import ApiKey
+    >>> api_key = ApiKey("foobar")
+    >>> api_key
+    ApiKey('foobar', source='user')
+    """
+
     DEMO_API_KEY = "demoapikeyot2022"
     API_KEY_FILES = (".opentopography.txt", "~/.opentopography.txt")
     API_KEY_ENV_VAR = "OPENTOPOGRAPHY_API_KEY"
@@ -15,10 +43,28 @@ class ApiKey:
         if not isinstance(api_key, str) or len(api_key) == 0:
             raise BadKeyError("invalid API key")
         self._api_key = api_key
-        self._source = source
+        self._source = ApiKey._validate_source(source)
+
+        if self.is_demo_key():
+            warnings.warn(
+                "You are using a demo key to fetch data from OpenTopography, functionality "
+                "will be limited. See https://bmi-topography.readthedocs.io/en/latest/#api-key "
+                "for more information."
+            )
+
+    @staticmethod
+    def _validate_source(source):
+        valid_sources = ["user", "env", "file", "demo"]
+        if isinstance(source, str) and source.split(":")[0] in valid_sources:
+            return source
+        else:
+            raise BadApiKeySource(
+                f"{source}: Invalid source (not one of {', '.join(valid_sources)}"
+            )
 
     @classmethod
     def from_env(cls):
+        """Get the key from and environment variables."""
         try:
             api_key = os.environ[ApiKey.API_KEY_ENV_VAR]
         except KeyError:
@@ -28,7 +74,8 @@ class ApiKey:
 
     @classmethod
     def from_file(cls):
-        if filepath := find_first_of(ApiKey.API_KEY_FILES):
+        """Read the key from a file."""
+        if filepath := _find_first_of(ApiKey.API_KEY_FILES):
             with open(filepath, "r") as fp:
                 api_key = fp.read().strip()
         else:
@@ -38,20 +85,25 @@ class ApiKey:
         return cls(api_key, source=f"file:{filepath}")
 
     @classmethod
-    def from_demo(cls):
-        return cls(ApiKey.use_demo_key(), source="demo")
-
-    @classmethod
     def from_sources(cls, api_key=None):
+        """Get a key from the first of a series of sources.
+
+        Look for a key from the following sources, returning the first found:
+        (1) provided by a user through the *api_key* keyword,
+        (2) provided by an environment variable,
+        (3) provided in a text file, and
+        (4) use a demo key
+        """
         for from_source in [partial(cls, api_key), cls.from_env, cls.from_file]:
             try:
                 return from_source()
             except (BadKeyError, MissingKeyError):
                 pass
-        return cls.from_demo()
+        return cls(ApiKey.DEMO_API_KEY, source="demo")
 
     @property
     def api_key(self):
+        """The API key."""
         return self._api_key
 
     @property
@@ -59,16 +111,8 @@ class ApiKey:
         """Where the API key came from."""
         return self._source
 
-    @staticmethod
-    def use_demo_key():
-        warnings.warn(
-            "You are using a demo key to fetch data from OpenTopography, functionality "
-            "will be limited. See https://bmi-topography.readthedocs.io/en/latest/#api-key "
-            "for more information."
-        )
-        return ApiKey.DEMO_API_KEY
-
     def is_demo_key(self):
+        """Check if the key is a demo key."""
         return self._api_key == ApiKey.DEMO_API_KEY
 
     def __repr__(self):
@@ -87,7 +131,8 @@ class ApiKey:
             return str(self) == val
 
 
-def find_first_of(files):
+def _find_first_of(files):
+    """Find the first existing file from a list of files."""
     found = None
     for path in (Path(name) for name in files):
         if path.expanduser().is_file():

--- a/bmi_topography/api_key.py
+++ b/bmi_topography/api_key.py
@@ -1,0 +1,89 @@
+import os
+import warnings
+from pathlib import Path
+
+
+class ApiKey:
+    DEMO_API_KEY = "demoapikeyot2022"
+    API_KEY_FILES = (".opentopography.txt", "~/.opentopography.txt")
+    API_KEY_ENV_VAR = "OPENTOPOGRAPHY_API_KEY"
+    
+    def __init__(self, api_key, source="user"):
+        if not isinstance(api_key, str) or len(api_key) == 0:
+            raise ValueError("invalid API key")
+        self._api_key = api_key
+        self._source = source
+    
+    @classmethod
+    def from_env(cls):
+        return cls(os.environ.get(ApiKey.API_KEY_ENV_VAR, ""), source="env")
+    
+    @classmethod
+    def from_file(cls):
+        if filepath := find_first_of(ApiKey.API_KEY_FILES):
+            with open(filepath, "r") as fp:
+                api_key = fp.read().strip()
+        else:
+            api_key = ""
+        return cls(api_key, source=f"file:{filepath}")
+    
+    @classmethod
+    def from_demo(cls):
+        return cls(ApiKey.use_demo_key(), source="demo")
+    
+    @classmethod
+    def from_sources(cls, api_key=None):
+        if api_key:
+            return cls(api_key)
+        for from_source in [cls.from_env, cls.from_file, cls.from_demo]:
+            try:
+                return from_source()
+            except ValueError:
+                pass
+        raise ValueError("unable to find an API key")
+    
+    @property
+    def api_key(self):
+        return self._api_key
+    
+    @property
+    def source(self):
+        """Where the API key came from."""
+        return self._source
+    
+    @staticmethod
+    def find_user_api_key():
+        """Search for an API key."""
+        if ApiKey.API_KEY_ENV_VAR in os.environ:
+            api_key, source = os.environ[ApiKey.API_KEY_ENV_VAR], "env"
+        else:
+            api_key, source = read_first_of(ApiKey.API_KEY_FILES).strip(), "file"
+    
+        return api_key
+    
+    @staticmethod
+    def use_demo_key():
+        warnings.warn(
+            "You are using a demo key to fetch data from OpenTopography, functionality "
+            "will be limited. See https://bmi-topography.readthedocs.io/en/latest/#api-key "
+            "for more information."
+        )
+        return ApiKey.DEMO_API_KEY
+    
+    def is_demo_key(self):
+        return self._api_key == ApiKey.DEMO_API_KEY
+    
+    def __repr__(self):
+        return f"ApiKey({self.api_key!r}, source={self.source!r})"
+    
+    def __str__(self):
+        return self.api_key
+
+
+def find_first_of(files):
+    found = None
+    for path in (Path(name) for name in files):
+        if path.expanduser().is_file():
+            found = path.expanduser()
+    return found
+

--- a/bmi_topography/api_key.py
+++ b/bmi_topography/api_key.py
@@ -7,17 +7,17 @@ class ApiKey:
     DEMO_API_KEY = "demoapikeyot2022"
     API_KEY_FILES = (".opentopography.txt", "~/.opentopography.txt")
     API_KEY_ENV_VAR = "OPENTOPOGRAPHY_API_KEY"
-    
+
     def __init__(self, api_key, source="user"):
         if not isinstance(api_key, str) or len(api_key) == 0:
             raise ValueError("invalid API key")
         self._api_key = api_key
         self._source = source
-    
+
     @classmethod
     def from_env(cls):
         return cls(os.environ.get(ApiKey.API_KEY_ENV_VAR, ""), source="env")
-    
+
     @classmethod
     def from_file(cls):
         if filepath := find_first_of(ApiKey.API_KEY_FILES):
@@ -26,11 +26,11 @@ class ApiKey:
         else:
             api_key = ""
         return cls(api_key, source=f"file:{filepath}")
-    
+
     @classmethod
     def from_demo(cls):
         return cls(ApiKey.use_demo_key(), source="demo")
-    
+
     @classmethod
     def from_sources(cls, api_key=None):
         if api_key:
@@ -41,26 +41,16 @@ class ApiKey:
             except ValueError:
                 pass
         raise ValueError("unable to find an API key")
-    
+
     @property
     def api_key(self):
         return self._api_key
-    
+
     @property
     def source(self):
         """Where the API key came from."""
         return self._source
-    
-    @staticmethod
-    def find_user_api_key():
-        """Search for an API key."""
-        if ApiKey.API_KEY_ENV_VAR in os.environ:
-            api_key, source = os.environ[ApiKey.API_KEY_ENV_VAR], "env"
-        else:
-            api_key, source = read_first_of(ApiKey.API_KEY_FILES).strip(), "file"
-    
-        return api_key
-    
+
     @staticmethod
     def use_demo_key():
         warnings.warn(
@@ -69,13 +59,13 @@ class ApiKey:
             "for more information."
         )
         return ApiKey.DEMO_API_KEY
-    
+
     def is_demo_key(self):
         return self._api_key == ApiKey.DEMO_API_KEY
-    
+
     def __repr__(self):
         return f"ApiKey({self.api_key!r}, source={self.source!r})"
-    
+
     def __str__(self):
         return self.api_key
 
@@ -96,4 +86,3 @@ def find_first_of(files):
             found = path.expanduser()
             break
     return found
-

--- a/bmi_topography/bbox.py
+++ b/bmi_topography/bbox.py
@@ -4,14 +4,7 @@ from typing import Tuple
 
 class BoundingBox:
 
-    """Represent a simple latitude-longiture bounding box.
-
-    Attributes
-    ----------
-    lower_left : tuple
-        The southwest corner of the box, given by (south, west)
-    upper_right : tuple
-        The northeast corner of the box, given by (north, east)
+    """Represent a simple latitude-longitude bounding box.
 
     Examples
     --------
@@ -78,10 +71,12 @@ class BoundingBox:
 
     @property
     def lower_left(self):
+        """The southwest corner of the box, given by tuple of *(south, west)*."""
         return self._lower_left
 
     @property
     def upper_right(self):
+        """The northeast corner of the box, given by tuple of *(north, east)*."""
         return self._upper_right
 
     @property

--- a/bmi_topography/errors.py
+++ b/bmi_topography/errors.py
@@ -1,0 +1,19 @@
+class BmiTopographyError(Exception):
+
+    """Base exception for all bmi_topography errors."""
+
+    pass
+
+
+class MissingKeyError(BmiTopographyError):
+
+    """Raise if an API key cannot be found."""
+
+    pass
+
+
+class BadKeyError(BmiTopographyError):
+
+    """Raise for an invalid key."""
+
+    pass

--- a/bmi_topography/errors.py
+++ b/bmi_topography/errors.py
@@ -17,3 +17,10 @@ class BadKeyError(BmiTopographyError):
     """Raise for an invalid key."""
 
     pass
+
+
+class BadApiKeySource(BmiTopographyError):
+
+    """Raise for an invalid API key source."""
+
+    pass

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -10,6 +10,44 @@ import xarray as xr
 from .bbox import BoundingBox
 
 
+class ApiKey:
+    DEMO_API_KEY = "demoapikeyot2022"
+    API_KEY_FILES = (".opentopography.txt", "~/.opentopography.txt")
+    API_KEY_ENV_VAR = "OPENTOPOGRAPHY_API_KEY"
+
+    def __init__(self, api_key=None):
+        if api_key is None:
+            self._api_key = find_user_api_key() or use_demo_key()
+        else:
+            self._api_key = api_key
+
+    @property
+    def api_key(self):
+        return self._api_key
+
+    @staticmethod
+    def find_user_api_key():
+        """Search for an API key."""
+        if ApiKey.API_KEY_ENV_VAR in os.environ:
+            api_key = os.environ[ApiKey.API_KEY_ENV_VAR]
+        else:
+            api_key = read_first_of(ApiKey.API_KEY_FILES).strip()
+
+        return api_key
+
+    @staticmethod
+    def use_demo_key():
+        warnings.warn(
+            "You are using a demo key to fetch data from OpenTopography, functionality "
+            "will be limited. See https://bmi-topography.readthedocs.io/en/latest/#api-key "
+            "for more information."
+        )
+        return ApiKey.DEMO_API_KEY
+
+    def is_demo_key(self):
+        return self._api_key == ApiKey.DEMO_API_KEY
+
+
 def find_user_api_key():
     """Search for an API key."""
     if "OPENTOPOGRAPHY_API_KEY" in os.environ:

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -77,6 +77,16 @@ def test_find_user_api_key_from_missing_file(tmpdir):
                 ApiKey.from_file()
 
 
+def test_default_to_demo_key(tmpdir):
+    """If a key can't be found, use the demo key"""
+    env = copy_environ(exclude="OPENTOPOGRAPHY_API_KEY")
+    with tmpdir.as_cwd():
+        with mock.patch.dict(os.environ, env, clear=True):
+            key = ApiKey.from_sources()
+            assert key.is_demo_key()
+            assert key.source == "demo"
+
+
 def test_read_first_missing(tmpdir):
     with tmpdir.as_cwd():
         assert find_first_of(["foo.txt"]) is None

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 
-from bmi_topography.topography import find_user_api_key, read_first_of, use_demo_key
+from bmi_topography.api_key import ApiKey, find_first_of
 
 
 def copy_environ(exclude=None):
@@ -19,7 +19,8 @@ def test_find_user_api_key_not_found():
     """The API key is not given anywhere"""
     env = copy_environ(exclude="OPENTOPOGRAPHY_API_KEY")
     with mock.patch.dict(os.environ, env, clear=True):
-        assert find_user_api_key() == ""
+        with pytest.raises(ValueError):
+            ApiKey.from_env()
 
 
 @mock.patch.dict(os.environ, {"OPENTOPOGRAPHY_API_KEY": "foo"})
@@ -28,7 +29,10 @@ def test_find_user_api_key_env(tmpdir):
     with tmpdir.as_cwd():
         with open(".opentopography.txt", "w") as fp:
             fp.write("bar")
-    assert find_user_api_key() == "foo"
+        key = ApiKey.from_sources()
+    assert key == "foo"
+    assert key.source == "env"
+    assert key == ApiKey("foo", source="env")
 
 
 @mock.patch.dict(os.environ, {"OPENTOPOGRAPHY_API_KEY": "foo"})
@@ -40,13 +44,16 @@ def test_find_user_api_key_from_file(tmpdir):
             fp.write("bar")
 
         with mock.patch.dict(os.environ, env, clear=True):
-            assert find_user_api_key() == "bar"
+            key = ApiKey.from_sources()
+            assert key == "bar"
+            assert key.source.startswith("file:")
+            assert key.source.endswith(".opentopography.txt")
 
 
 def test_read_first_missing(tmpdir):
     with tmpdir.as_cwd():
-        assert read_first_of(["foo.txt"]) == ""
-        assert read_first_of([]) == ""
+        assert find_first_of(["foo.txt"]) is None
+        assert find_first_of([]) is None
 
 
 def test_read_first_file(tmpdir):
@@ -56,16 +63,16 @@ def test_read_first_file(tmpdir):
         with open("bar.txt", "w") as fp:
             fp.write("bar")
 
-        assert read_first_of(["foo.txt", "bar.txt"]) == "foo"
-        assert read_first_of(["bar.txt", "foo.txt"]) == "bar"
+        assert find_first_of(["foo.txt", "bar.txt"]).name == "foo.txt"
+        assert find_first_of(["bar.txt", "foo.txt"]).name == "bar.txt"
 
 
 def test_use_demo_key_is_a_string():
-    demo_key = use_demo_key()
-    assert isinstance(demo_key, str)
-    assert len(demo_key) > 0
+    key = ApiKey.from_demo()
+    assert len(key) > 0
+    assert key.source == "demo"
 
 
 def test_use_demo_key_issues_warning():
     with pytest.warns(UserWarning):
-        use_demo_key()
+        ApiKey.from_demo()


### PR DESCRIPTION
This pull request tries to address #40 but keeping track where a user's API key came from (i.e. was it supplied as a keyword, through an environment variable, through a file, or a demo key).

