### PR TITLE
Update contents of source and binary distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include *.md
+include *.cff
 include environment.yml
 include Makefile
-recursive-include examples *
-recursive-exclude docs *
-recursive-exclude tests *
+include examples/*
+recursive-include tests *
+recursive-include docs *

--- a/Makefile
+++ b/Makefile
@@ -81,15 +81,15 @@ setup: ## generate a setup.py file for release tools
 	echo "import setuptools" >> setup.py
 	echo "setuptools.setup()" >> setup.py
 
-build: clean ## build and package a release
+dist: clean ## build and package a release
 	python -m build
 	ls -l dist
 
-testpypi: build ## upload a release to TestPyPI
+testpypi: dist ## upload a release to TestPyPI
 	twine check dist/*
 	twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
-pypi: build ## upload a release to PyPI
+pypi: dist ## upload a release to PyPI
 	twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
 
 prerelease: clean setup ## generate a prerelease with zest.releaser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,10 +69,7 @@ version = {attr = "bmi_topography._version.__version__"}
 
 [tool.setuptools.packages.find]
 where = ["."]
-exclude = [
-  "bmi_topography.tests*",
-  "bmi_topography.examples*",
-]
+include = ["bmi_topography*"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"


### PR DESCRIPTION
This PR refreshes what goes into the package's sdist and wheel, adding content to the sdist and trimming it from the wheel.

These changes were motivated by what @mcflugen is doing in https://github.com/landlab/landlab/pull/1445.