### PR TITLE
Use rio accessor for geospatial information

### DIFF
--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -42,6 +42,7 @@ jobs:
         run: make install
 
       - name: Test
+        if: ${{ !(matrix.os == 'windows-latest' && matrix.python-version == '3.10') }}
         env:
           OPENTOPOGRAPHY_API_KEY: ${{ secrets.OPENTOPOGRAPHY_API_KEY }}
         run: |

--- a/bmi_topography/bmi.py
+++ b/bmi_topography/bmi.py
@@ -657,14 +657,12 @@ class BmiTopography(Bmi):
             self._config = Topography.DEFAULT.copy()
         self._da = Topography(**self._config).load()
 
-        geotransform = list(map(float, self._da.spatial_ref.GeoTransform.split(" ")))
-
         self._grid = {
             0: BmiGridUniformRectilinear(
-                shape=(self._da.sizes["y"], self._da.sizes["x"]),
+                shape=self._da.rio.shape,
                 yx_spacing=(
-                    abs(geotransform[-1]),
-                    abs(geotransform[1]),
+                    self._da.rio.transform().e,
+                    self._da.rio.transform().a,
                 ),
                 yx_of_lower_left=(
                     float(self._da.y.min().data),
@@ -677,7 +675,7 @@ class BmiTopography(Bmi):
             dtype=str(self._da.values.dtype),
             itemsize=self._da.values.itemsize,
             nbytes=self._da.values.nbytes,
-            location=self._da.attrs["location"],
+            location="face",
             units=self._da.attrs["units"],
             grid=0,
         )

--- a/bmi_topography/bmi.py
+++ b/bmi_topography/bmi.py
@@ -661,8 +661,8 @@ class BmiTopography(Bmi):
             0: BmiGridUniformRectilinear(
                 shape=self._da.rio.shape,
                 yx_spacing=(
-                    self._da.rio.transform().e,
-                    self._da.rio.transform().a,
+                    abs(self._da.rio.transform().e),
+                    abs(self._da.rio.transform().a),
                 ),
                 yx_of_lower_left=(
                     float(self._da.y.min().data),

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -175,6 +175,8 @@ class Topography:
         if self._da is None:
             self._da = rioxarray.open_rasterio(self.fetch())
             self._da.name = self.dem_type
-            self._da.attrs["units"] = CRS(self._da.spatial_ref.crs_wkt).prime_meridian.unit_name
+            self._da.attrs["units"] = CRS(
+                self._da.spatial_ref.crs_wkt
+            ).prime_meridian.unit_name
 
         return self._da

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -175,6 +175,6 @@ class Topography:
             self._da = rioxarray.open_rasterio(self.fetch())
             self._da.name = self.dem_type
             self._da.attrs["units"] = "meters"
-            self._da.attrs["location"] = "node"
+            self._da.attrs["location"] = "face"
 
         return self._da

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import requests
 import rioxarray
-from pyproj import CRS
+from rasterio.crs import CRS
 
 from .api_key import ApiKey
 from .bbox import BoundingBox
@@ -175,8 +175,11 @@ class Topography:
         if self._da is None:
             self._da = rioxarray.open_rasterio(self.fetch())
             self._da.name = self.dem_type
-            self._da.attrs["units"] = CRS(
-                self._da.spatial_ref.crs_wkt
-            ).prime_meridian.unit_name
+
+            crs = CRS.from_wkt(self._da.spatial_ref.crs_wkt)
+            if crs.is_geographic:
+                self._da.attrs["units"] = "degrees"
+            else:
+                self._da.attrs["units"] = crs.linear_units
 
         return self._da

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import requests
 import rioxarray
+from pyproj import CRS
 
 from .api_key import ApiKey
 from .bbox import BoundingBox
@@ -12,7 +13,7 @@ from .bbox import BoundingBox
 
 class Topography:
 
-    """Fetch and cache NASA SRTM land elevation data."""
+    """Fetch and cache land elevation data from OpenTopography."""
 
     SCHEME = "https"
     NETLOC = "portal.opentopography.org"
@@ -174,7 +175,6 @@ class Topography:
         if self._da is None:
             self._da = rioxarray.open_rasterio(self.fetch())
             self._da.name = self.dem_type
-            self._da.attrs["units"] = "meters"
-            self._da.attrs["location"] = "face"
+            self._da.attrs["units"] = CRS(self._da.spatial_ref.crs_wkt).prime_meridian.unit_name
 
         return self._da

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,6 @@ dependencies:
   - pyyaml
   - xarray
   - rioxarray
-  - pyproj
   - bmipy
   - make
   - black

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - pyyaml
   - xarray
   - rioxarray
+  - pyproj
   - bmipy
   - make
   - black

--- a/tests/test_topography.py
+++ b/tests/test_topography.py
@@ -105,3 +105,4 @@ def test_load(tmpdir, shared_datadir):
         )
         topo.load()
         assert topo.da is not None
+        assert topo.da.attrs["units"] == "degrees"


### PR DESCRIPTION
This PR updates *bmi-topography* to use the *rioxarray* [rio accessor](https://corteva.github.io/rioxarray/stable/rioxarray.html#rioxarray-rio-accessors) for geopspatial information.