### PR TITLE
Use nox in CI testing

### DIFF
--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -43,12 +43,12 @@ jobs:
         env:
           OPENTOPOGRAPHY_API_KEY: ${{ secrets.OPENTOPOGRAPHY_API_KEY }}
         run: |
-          pytest --cov=bmi_topography --cov-report=xml:./coverage.xml --cov-config=./setup.cfg -vvv
+          nox -s test --python ${{ matrix.python-version }}
 
       - name: Test BMI
         if: ${{ matrix.python-version == '3.9' }}  # stuck at py39 pending pymt update
         run: |
-          bmi-test bmi_topography:BmiTopography --config-file=./examples/config.yaml --root-dir=./examples -vvv
+          nox -s test-bmi --python ${{ matrix.python-version }}
 
       - name: Coveralls
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'

--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -52,4 +52,4 @@ jobs:
 
       - name: Coveralls
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
-        uses: AndreMiras/coveralls-python-action@v20201129
+        uses: AndreMiras/coveralls-python-action@develop

--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@ Changes for bmi-topography
 ==========================
 
 0.8.3 (unreleased)
----------------------
+------------------
 
 - Nothing changed yet.
 

--- a/environment.yml
+++ b/environment.yml
@@ -19,6 +19,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-datadir
+  - coverage
   - coveralls
   - bmi-tester
   - sphinx
@@ -29,5 +30,3 @@ dependencies:
   - build
   - twine
   - zest.releaser
-  - pip:
-    - coverage[toml]

--- a/environment.yml
+++ b/environment.yml
@@ -29,3 +29,5 @@ dependencies:
   - build
   - twine
   - zest.releaser
+  - pip:
+    - coverage[toml]

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,6 +26,7 @@ def test(session: nox.Session) -> None:
 
     if "CI" in os.environ:
         args.append(f"--cov-report=xml:{ROOT.absolute()!s}/coverage.xml")
+        args.append(f"--cov-config={ROOT.absolute()!s}/setup.cfg")
     session.run("pytest", *args)
 
     if "CI" not in os.environ:

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,14 +17,25 @@ PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
 def test(session: nox.Session) -> None:
     """Run the tests."""
     session.install(".[testing]")
-    args = session.posargs or ["--cov", "--cov-report=term", "-vvv"]
+
+    args = [
+        "--cov",
+        PACKAGE,
+        "-vvv",
+    ] + session.posargs
+
+    if "CI" in os.environ:
+        args.append(f"--cov-report=xml:{ROOT.absolute()!s}/coverage.xml")
     session.run("pytest", *args)
+
+    if "CI" not in os.environ:
+        session.run("coverage", "report", "--ignore-errors", "--show-missing")
 
 
 @nox.session(name="test-bmi", python=PYTHON_VERSIONS, venv_backend="conda")
 def test_bmi(session: nox.Session) -> None:
     """Test the Basic Model Interface."""
-    session.conda_install("bmi-tester", "pymt")
+    session.conda_install("bmi-tester", "pymt>=1.3")
     session.install(".")
     session.run(
         "bmi-test",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ testing = [
   "pytest",
   "pytest-cov",
   "pytest-datadir",
-  "coverage[toml]",
   "coveralls",
 ]
 docs = [
@@ -113,6 +112,3 @@ include_trailing_comma = true
 force_grid_wrap = 0
 combine_as_imports = true
 line_length = 88
-
-[tool.coverage.run]
-relative_files = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ testing = [
   "pytest",
   "pytest-cov",
   "pytest-datadir",
+  "coverage",
   "coveralls",
 ]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ testing = [
   "pytest",
   "pytest-cov",
   "pytest-datadir",
+  "coverage[toml]",
   "coveralls",
 ]
 docs = [
@@ -112,3 +113,6 @@ include_trailing_comma = true
 force_grid_wrap = 0
 combine_as_imports = true
 line_length = 88
+
+[tool.coverage.run]
+relative_files = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[coverage:run]
+relative_files = True
+
 [flake8]
 exclude = docs
 ignore =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[coverage:run]
-relative_files = True
-
 [flake8]
 exclude = docs
 ignore =


### PR DESCRIPTION
This PR updates the CI *test* job to use the `test` and `bmi-test`*nox* sessions that were set up in #51. This involved moving some code from the CI *test* job to the *nox* sessions.

Other improvements:

* Use newer *checkout* action version in CI
* Use newer *coveralls* action version in CI
* Explicitly require the *coverage* package
* Fix error in changelog