### PR TITLE
Fix docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,4 +15,3 @@ python:
     - requirements: docs/source/requirements.txt
     - method: pip
       path: .
-  system_packages: false


### PR DESCRIPTION
This PR contains one small fix: removing the now invalid `system_packages` setting from the rtfd configuration.