### PR TITLE
Add new ot global raster datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The *bmi-topography* library provides access to the following global raster data
 * NASADEM (NASADEM Global DEM)
 * COP30 (Copernicus Global DSM 30m)
 * COP90 (Copernicus Global DSM 90m)
+* EU_DTM (DTM 30m)
+* GEDI_L3 (DTM 1000m)
 
 The library includes an API and a CLI that accept
 the dataset type,
@@ -81,7 +83,7 @@ there are three ways to use it with *bmi-topography*:
 3. *dot file*: Put the API key in the file `.opentopography.txt` in the current directory or in your home directory.
 
 If you attempt to use *bmi-topography* to access an OpenTopography dataset without an API key,
-you'll get a error like this: 
+you'll get a error like this:
 ```
 requests.exceptions.HTTPError: 401 Client Error: This dataset requires an API Key for access.
 ```

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -41,6 +41,8 @@ class Topography:
         "NASADEM",
         "COP30",
         "COP90",
+        "EU_DTM",
+        "GEDI_L3",
     )
     VALID_OUTPUT_FORMATS = {"GTiff": "tif", "AAIGrid": "asc", "HFA": "img"}
 


### PR DESCRIPTION
This PR updates the list of available OpenTopography [global] raster datasets. See #55

- [ ] EU_DTM (DTM 30m) is western Europe-only dataset, so current test point fails the `fetch_load` tests because returns an empty file. See discussion.
- [x] GEDI_L3 (DTM 1000m) is standard global coverage dataset, pass all tests.