### PR TITLE
Set minimum python>=3.10

### DIFF
--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
           nox -s test --python ${{ matrix.python-version }}
 
       - name: Test BMI
-        if: ${{ matrix.python-version == '3.9' }}  # stuck at py39 pending pymt update
+        if: ${{ matrix.python-version == '3.12' }}
         run: |
           nox -s test-bmi --python ${{ matrix.python-version }}
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ name: topography
 channels:
   - conda-forge
 dependencies:
-  - python >=3.9
+  - python >=3.10
   - pip
   - requests
   - numpy

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,7 @@ PACKAGE = PROJECT.replace("-", "_")
 HERE = pathlib.Path(__file__)
 ROOT = HERE.parent
 PATHS = [PACKAGE, "docs", "examples", "tests", HERE.name]
-PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12"]
+PYTHON_VERSIONS = ["3.10", "3.11", "3.12"]
 
 
 @nox.session(python=PYTHON_VERSIONS)

--- a/noxfile.py
+++ b/noxfile.py
@@ -36,15 +36,15 @@ def test(session: nox.Session) -> None:
 @nox.session(name="test-bmi", python=PYTHON_VERSIONS, venv_backend="conda")
 def test_bmi(session: nox.Session) -> None:
     """Test the Basic Model Interface."""
-    session.conda_install("bmi-tester", "pymt>=1.3")
+    session.install("bmi-tester>=0.5.9")
     session.install(".")
     session.run(
         "bmi-test",
-        "bmi_topography:BmiTopography",
+        f"{PACKAGE}:BmiTopography",
         "--config-file",
-        "./examples/config.yaml",
+        f"{ROOT}/examples/config.yaml",
         "--root-dir",
-        "./examples",
+        "examples",
         "-vvv",
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ keywords = [
 license = {text = "MIT License"}
 classifiers = [
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -37,7 +36,7 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "Intended Audience :: Education",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
   "requests",
   "numpy",


### PR DESCRIPTION
This PR drops testing for Python 3.9 (although *bmi-topography* should still work in it, at least for now). I also touched the *nox* `bmi-test` session to get it working with the latest version of *bmi-tester*.

The docs CI workflow is still failing (see #61). I'll fix it in a subsequent PR.

This fixes #66.