### PR TITLE
Cancel in-progress CI workflows on new push

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,10 @@ name: Documentation
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
 
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,10 @@ name: Lint
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
 
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,12 @@ name: Test
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
+
   test:
     if:
       github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
-name: Build/Test CI
+name: Test
 
 on: [push, pull_request]
 
 jobs:
-  build-and-test:
+  test:
     if:
       github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
       github.repository

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.8327417.svg)](https://doi.org/10.5281/zenodo.8327417)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/bmi-topography.svg)](https://anaconda.org/conda-forge/bmi-topography)
 [![PyPI](https://img.shields.io/pypi/v/bmi-topography)](https://pypi.org/project/bmi-topography)
-[![Build/Test CI](https://github.com/csdms/bmi-topography/actions/workflows/build-test-ci.yml/badge.svg)](https://github.com/csdms/bmi-topography/actions/workflows/build-test-ci.yml)
+[![Build/Test CI](https://github.com/csdms/bmi-topography/actions/workflows/test.yml/badge.svg)](https://github.com/csdms/bmi-topography/actions/workflows/test.yml)
 [![Coverage Status](https://coveralls.io/repos/github/csdms/bmi-topography/badge.svg?branch=main)](https://coveralls.io/github/csdms/bmi-topography?branch=main)
 [![Documentation Status](https://readthedocs.org/projects/bmi-topography/badge/?version=latest)](https://bmi-topography.readthedocs.io/en/latest/?badge=latest)
 


### PR DESCRIPTION
This PR updates the *test*, *lint*, and *docs* CI workflows to allow them to be canceled when a new push occurs. The workflows are then started for the newly-pushed changes.

I learned about this from https://github.com/landlab/landlab/pull/1971.