### PR TITLE
Simplify the test CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,18 +31,10 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
-          environment-file: environment.yml
-          activate-environment: topography
           python-version: ${{ matrix.python-version }}
-          auto-activate-base: false
 
-      - name: Show conda installation info
-        run: |
-          conda info
-          conda list
-
-      - name: Install package
-        run: pip install -e .
+      - name: Install nox
+        run: pip install nox
 
       - name: Test latest Python version
         env:


### PR DESCRIPTION
This PR makes a minor change to the *test* CI workflow: Instead of setting up a conda environment with all required packages, use the default `test` environment provided by Mambaforge and only install *nox*, which sets up its own virtual environments for sessions.
