### PR TITLE
Update project metadata and CI workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
-          python-version: 3.11
+          python-version: 3.12
           auto-activate-base: false
 
       - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
-          python-version: 3.11
+          python-version: 3.12
           auto-activate-base: false
 
       - name: Install nox

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,11 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: actions/setup-python@v5
         with:
-          miniforge-version: latest
           python-version: 3.12
-          auto-activate-base: false
 
       - name: Install nox
         run: pip install nox

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -26,12 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - name: Install Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          miniforge-variant: Miniforge3
-          miniforge-version: latest
-          auto-update-conda: true
 
       - name: Install nox
         run: pip install nox

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Check Jupyter notebooks
         env:
+          OPENTOPOGRAPHY_API_KEY: ${{ secrets.OPENTOPOGRAPHY_API_KEY }}
           MPLBACKEND: "Agg"
         run: |
           nox --verbose -s check-notebooks --force-pythons="${{ matrix.python-version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - name: Install Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
-          miniforge-version: latest
           python-version: ${{ matrix.python-version }}
 
       - name: Install nox

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ is available at https://bmi-topography.readthedocs.io.
 
 <!-- Links (by alpha) -->
 
-[bmi]: https://bmi.readthedocs.io
+[bmi]: https://bmi.csdms.io
 [bmi-topo-examples]: https://github.com/csdms/bmi-topography/tree/main/examples
 [bmi-topo-repo]: https://github.com/csdms/bmi-topography
 [conda-env]: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/bmi-topography)](https://pypi.org/project/bmi-topography)
 [![Build/Test CI](https://github.com/csdms/bmi-topography/actions/workflows/test.yml/badge.svg)](https://github.com/csdms/bmi-topography/actions/workflows/test.yml)
 [![Coverage Status](https://coveralls.io/repos/github/csdms/bmi-topography/badge.svg?branch=main)](https://coveralls.io/github/csdms/bmi-topography?branch=main)
-[![Documentation Status](https://readthedocs.org/projects/bmi-topography/badge/?version=latest)](https://bmi-topography.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/bmi-topography/badge/?version=latest)](https://bmi-topography.csdms.io/en/latest/?badge=latest)
 
 # bmi-topography
 
@@ -187,7 +187,7 @@ included in the [examples][bmi-topo-examples] directory
 of the *bmi-topography* repository.
 
 User and developer documentation for *bmi-topography*
-is available at https://bmi-topography.readthedocs.io.
+is available at https://bmi-topography.csdms.io.
 
 <!-- Links (by alpha) -->
 

--- a/bmi_topography/api_key.py
+++ b/bmi_topography/api_key.py
@@ -47,7 +47,7 @@ class ApiKey:
         if self.is_demo_key():
             warnings.warn(
                 "You are using a demo key to fetch data from OpenTopography, functionality "
-                "will be limited. See https://bmi-topography.readthedocs.io/en/latest/#api-key "
+                "will be limited. See https://bmi-topography.csdms.io/en/latest/#api-key "
                 "for more information."
             )
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx
 recommonmark
 pandoc
+importlib-metadata

--- a/docs/source/CHANGES.rst
+++ b/docs/source/CHANGES.rst
@@ -1,7 +1,12 @@
 Changes for bmi-topography
 ==========================
 
-0.8.5 (unreleased)
+0.8.6 (unreleased)
+------------------
+
+-  Make an examples landing page (#77)
+
+0.8.5 (2024-08-18)
 ------------------
 
 -  Check example notebooks (#75)
@@ -10,6 +15,8 @@ Changes for bmi-topography
 -  Use pre-commit for linting and formatting (#72)
 -  De-lint project files (#71)
 
+.. _section-1:
+
 0.8.4 (2024-03-28)
 ------------------
 
@@ -17,7 +24,7 @@ Changes for bmi-topography
 -  Set minimum python>=3.10 (#67)
 -  Link to project contributing and code of conduct docs (#65)
 
-.. _section-1:
+.. _section-2:
 
 0.8.3 (2023-12-18)
 ------------------
@@ -27,14 +34,14 @@ Changes for bmi-topography
 -  Fix failing docs build (#58)
 -  Use nox in CI testing (#54)
 
-.. _section-2:
+.. _section-3:
 
 0.8.2 (2023-02-06)
 ------------------
 
 -  Fix problem getting CRS info for AAIGrid type (#53)
 
-.. _section-3:
+.. _section-4:
 
 0.8.1 (2023-01-27)
 ------------------
@@ -45,7 +52,7 @@ Changes for bmi-topography
 -  Use rio accessor for geospatial information (#47)
 -  Update contents of source and binary distributions (#46)
 
-.. _section-4:
+.. _section-5:
 
 0.8 (2022-07-05)
 ----------------
@@ -53,14 +60,14 @@ Changes for bmi-topography
 -  Switch from xarray to rioxarray (#45)
 -  Move metadata from setup.cfg to pyproject.toml (#44)
 
-.. _section-5:
+.. _section-6:
 
 0.7.1 (2022-06-03)
 ------------------
 
 -  Provide a better reason for 401 errors (#41)
 
-.. _section-6:
+.. _section-7:
 
 0.7 (2022-03-24)
 ----------------
@@ -68,7 +75,7 @@ Changes for bmi-topography
 -  Support all OpenTopography global datasets (#39)
 -  Create test matrix of datasets and file types (#38)
 
-.. _section-7:
+.. _section-8:
 
 0.6 (2022-02-17)
 ----------------
@@ -76,7 +83,7 @@ Changes for bmi-topography
 -  Use dashes in command line options (#36)
 -  Use a demo API key if a user key can’t be found (#34)
 
-.. _section-8:
+.. _section-9:
 
 0.5.1 (2022-02-15)
 ------------------
@@ -85,7 +92,7 @@ Changes for bmi-topography
 -  Add text to exception raised when API key is missing (#32)
 -  Use new black syntax (#31)
 
-.. _section-9:
+.. _section-10:
 
 0.5 (2022-01-25)
 ----------------
@@ -94,7 +101,7 @@ Changes for bmi-topography
 -  Add python 3.10 to tests (#24)
 -  Address technical debt (#22)
 
-.. _section-10:
+.. _section-11:
 
 0.4 (2021-09-03)
 ----------------
@@ -104,7 +111,7 @@ Changes for bmi-topography
 -  Add format job to CI
 -  Use CITATION.cff file
 
-.. _section-11:
+.. _section-12:
 
 0.3.2 (2021-04-23)
 ------------------
@@ -113,7 +120,7 @@ Changes for bmi-topography
 -  Fix typos, update text in example notebooks
 -  Create CREDITS.md and rearrange docs
 
-.. _section-12:
+.. _section-13:
 
 0.3.1 (2021-03-04)
 ------------------
@@ -121,7 +128,7 @@ Changes for bmi-topography
 -  Install with conda
 -  Include shell script demonstrating CLI
 
-.. _section-13:
+.. _section-14:
 
 0.3 (2021-02-25)
 ----------------
@@ -129,7 +136,7 @@ Changes for bmi-topography
 -  Update README with overview and install instructions
 -  Write documentation
 
-.. _section-14:
+.. _section-15:
 
 0.2 (2021-02-24)
 ----------------
@@ -139,7 +146,7 @@ Changes for bmi-topography
 -  Include sample config file and Jupyter Notebook to demo BMI
 -  Add CI with GitHub Actions
 
-.. _section-15:
+.. _section-16:
 
 0.1.1 (2021-02-22)
 ------------------
@@ -147,7 +154,7 @@ Changes for bmi-topography
 -  Add Makefile rule to test upload to TestPyPI
 -  Test upload to TestPyPI
 
-.. _section-16:
+.. _section-17:
 
 0.1 (2021-02-22)
 ----------------

--- a/docs/source/README.rst
+++ b/docs/source/README.rst
@@ -214,7 +214,7 @@ script, and shell script included in the
 directory of the *bmi-topography* repository.
 
 User and developer documentation for *bmi-topography* is available at
-https://bmi-topography.readthedocs.io.
+https://bmi-topography.csdms.io.
 
 .. raw:: html
 
@@ -231,4 +231,4 @@ https://bmi-topography.readthedocs.io.
 .. |Coverage Status| image:: https://coveralls.io/repos/github/csdms/bmi-topography/badge.svg?branch=main
    :target: https://coveralls.io/github/csdms/bmi-topography?branch=main
 .. |Documentation Status| image:: https://readthedocs.org/projects/bmi-topography/badge/?version=latest
-   :target: https://bmi-topography.readthedocs.io/en/latest/?badge=latest
+   :target: https://bmi-topography.csdms.io/en/latest/?badge=latest

--- a/docs/source/README.rst
+++ b/docs/source/README.rst
@@ -32,10 +32,10 @@ through
 `rioxarray <https://corteva.github.io/rioxarray/stable/getting_started/getting_started.html>`__.
 
 The *bmi-topography* API is wrapped with a `Basic Model
-Interface <https://bmi.readthedocs.io>`__ (BMI), which provides a
-standard set of functions for coupling with data or models that also
-expose a BMI. More information on the BMI can found in its
-`documentation <https://bmi.readthedocs.io>`__.
+Interface <https://bmi.csdms.io>`__ (BMI), which provides a standard set
+of functions for coupling with data or models that also expose a BMI.
+More information on the BMI can found in its
+`documentation <https://bmi.csdms.io>`__.
 
 Installation
 ------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@
 # sys.path.insert(0, os.path.abspath('.'))
 import datetime
 
-import pkg_resources
+from importlib.metadata import version as package_version
 
 # The master toctree document.
 master_doc = "index"
@@ -25,7 +25,7 @@ master_doc = "index"
 
 project = "bmi-topography"
 author = "Community Surface Dynamics Modeling System"
-version = pkg_resources.get_distribution("bmi_topography").version
+version = package_version("bmi_topography")
 release = version
 this_year = datetime.date.today().year
 copyright = f"{this_year}, {author}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,6 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 import datetime
-
 from importlib.metadata import version as package_version
 
 # The master toctree document.

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,7 +33,7 @@ def test(session: nox.Session) -> None:
         session.run("coverage", "report", "--ignore-errors", "--show-missing")
 
 
-@nox.session(name="test-bmi", python=PYTHON_VERSIONS, venv_backend="conda")
+@nox.session(name="test-bmi", python=PYTHON_VERSIONS)
 def test_bmi(session: nox.Session) -> None:
     """Test the Basic Model Interface."""
     session.install("bmi-tester>=0.5.9")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ docs = [
   "sphinx",
   "recommonmark",
   "pandoc",
+  "importlib-metadata",
 ]
 examples = [
   "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dynamic = ["readme", "version"]
 
 [project.urls]
 Homepage = "https://csdms.colorado.edu"
-Documentation = "https://bmi-topography.readthedocs.io/"
+Documentation = "https://bmi-topography.csdms.io/"
 Repository = "https://github.com/csdms/bmi-topography"
 Changelog = "https://github.com/csdms/bmi-topography/blob/main/CHANGES.md"
 Forum = "https://forum.csdms.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["setuptools", "wheel"]
-build-backend = "setuptools.build_meta"
-
 [project]
 name = "bmi-topography"
 description = "Fetch and cache land elevation data from OpenTopography"
@@ -30,6 +26,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Intended Audience :: Developers",
@@ -53,6 +50,7 @@ Homepage = "https://csdms.colorado.edu"
 Documentation = "https://bmi-topography.readthedocs.io/"
 Repository = "https://github.com/csdms/bmi-topography"
 Changelog = "https://github.com/csdms/bmi-topography/blob/main/CHANGES.md"
+Forum = "https://forum.csdms.io"
 
 [project.optional-dependencies]
 dev = [
@@ -81,6 +79,10 @@ examples = [
 
 [project.scripts]
 bmi-topography = "bmi_topography.cli:main"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools.dynamic]
 readme = {file = ["README.md", "CREDITS.md", "LICENSE.md"], content-type = "text/markdown"}


### PR DESCRIPTION
This PR contains a set of maintenance updates to the project metadata files and CI workflows.

This includes:
* Switch to *venv* from *conda* for the CI workflows (except for the docs)
* Point to the csdms.io url for docs
* Use Python 3.12 for lint and docs workflows
