### PR TITLE
Add a function to clear data files from a directory

### DIFF
--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -4,7 +4,6 @@ import os
 import urllib
 import warnings
 from pathlib import Path
-import itertools
 
 import requests
 import rioxarray
@@ -188,7 +187,7 @@ class Topography:
     def clear_cache(dir):
         cache_dir = Path(dir).expanduser()
 
-        cache_files = list()
+        cache_files = []
         for fext in Topography.VALID_OUTPUT_FORMATS.values():
             cache_files.extend(cache_dir.glob(f"*.{fext}"))
 

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -4,6 +4,7 @@ import os
 import urllib
 import warnings
 from pathlib import Path
+import itertools
 
 import requests
 import rioxarray
@@ -182,6 +183,18 @@ class Topography:
                     fp.write(chunk)
 
         return fname.absolute()
+
+    @staticmethod
+    def clear_cache(dir):
+        cache_dir = Path(dir).expanduser()
+
+        cache_files = list()
+        for fext in Topography.VALID_OUTPUT_FORMATS.values():
+            cache_files.extend(cache_dir.glob(f"*.{fext}"))
+
+        for cache_file in cache_files:
+            cache_file.unlink()
+            print(f"rm {cache_file}")
 
     @property
     def da(self):

--- a/tests/test_topography.py
+++ b/tests/test_topography.py
@@ -22,14 +22,9 @@ def test_invalid_output_format():
 
 
 def test_valid_bbox():
-    topo = Topography(
-        dem_type=Topography.DEFAULT["dem_type"],
-        output_format=Topography.DEFAULT["output_format"],
-        south=Topography.DEFAULT["south"],
-        west=Topography.DEFAULT["west"],
-        north=Topography.DEFAULT["north"],
-        east=Topography.DEFAULT["east"],
-    )
+    params = Topography.DEFAULT.copy()
+    topo = Topography(**params)
+
     assert topo.bbox.south == Topography.DEFAULT["south"]
     assert topo.bbox.west == Topography.DEFAULT["west"]
     assert topo.bbox.north == Topography.DEFAULT["north"]
@@ -41,30 +36,20 @@ def test_valid_bbox():
 @pytest.mark.parametrize("cache_dir", (".", "./cache"))
 def test_cache_dir(tmpdir, cache_dir):
     with tmpdir.as_cwd():
-        topo = Topography(
-            dem_type=Topography.DEFAULT["dem_type"],
-            output_format=Topography.DEFAULT["output_format"],
-            south=Topography.DEFAULT["south"],
-            west=Topography.DEFAULT["west"],
-            north=Topography.DEFAULT["north"],
-            east=Topography.DEFAULT["east"],
-            cache_dir=cache_dir,
-        )
+        params = Topography.DEFAULT.copy()
+        params["cache_dir"] = cache_dir
+        topo = Topography(**params)
+
         assert topo.cache_dir.is_absolute()
         assert list(topo.cache_dir.glob("*.tif")) == []
 
 
 def test_cached_data(tmpdir, shared_datadir):
     with tmpdir.as_cwd():
-        Topography(
-            dem_type=Topography.DEFAULT["dem_type"],
-            output_format=Topography.DEFAULT["output_format"],
-            south=Topography.DEFAULT["south"],
-            west=Topography.DEFAULT["west"],
-            north=Topography.DEFAULT["north"],
-            east=Topography.DEFAULT["east"],
-            cache_dir=shared_datadir,
-        )
+        params = Topography.DEFAULT.copy()
+        params["cache_dir"] = shared_datadir
+        Topography(**params)
+
         assert len(tmpdir.listdir(fil=lambda f: f.ext == ".tif")) == 0
 
 

--- a/tests/test_topography.py
+++ b/tests/test_topography.py
@@ -1,6 +1,7 @@
 """Test Topography class"""
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -51,6 +52,22 @@ def test_cached_data(tmpdir, shared_datadir):
         Topography(**params)
 
         assert len(tmpdir.listdir(fil=lambda f: f.ext == ".tif")) == 0
+
+
+def test_clear_cache(tmpdir):
+    with tmpdir.as_cwd():
+        dem_file = []
+        for fext in Topography.VALID_OUTPUT_FORMATS.values():
+            dem_file.append(Path(f"foo.{fext}"))
+
+        for file in dem_file:
+            file.touch()
+
+        for file in dem_file:
+            assert file.is_file()
+        Topography.clear_cache(tmpdir)
+        for file in dem_file:
+            assert not file.is_file()
 
 
 @pytest.mark.parametrize("server_name", tuple(Topography.SERVER_NAME.values()))


### PR DESCRIPTION
This PR adds a `clear_cache` function to the Topography class as a static method. It takes as input a directory path, and it deletes the `*.tif`, `*.img`, and `*.asc` files it finds therein.

This PR partially addresses #69, but it isn't provided (yet) as a command-line option.

Unrelated, but since I was looking at tests: I simplified how a Topography instance is created in a few of the other tests in `test_topography.py` (aac0ba95f266f1f204dfefeb54344919a20aa5f3).