### PR TITLE
Set default output format to GTiff

### DIFF
--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -58,7 +58,7 @@ class Topography:
         north=None,
         west=None,
         east=None,
-        output_format=None,
+        output_format="GTiff",
         cache_dir=None,
         api_key=None,
     ):

--- a/tests/test_topography.py
+++ b/tests/test_topography.py
@@ -17,6 +17,15 @@ def test_invalid_dem_type():
         Topography(dem_type="foo", output_format=Topography.DEFAULT["output_format"])
 
 
+def test_default_output_format():
+    params = Topography.DEFAULT.copy()
+    params.pop("output_format")
+    assert "output_format" in params.keys() is False
+
+    topo = Topography(**params)
+    assert topo.output_format == "GTiff"
+
+
 def test_invalid_output_format():
     with pytest.raises(ValueError):
         Topography(dem_type=Topography.DEFAULT["dem_type"], output_format="foo")

--- a/tests/test_topography.py
+++ b/tests/test_topography.py
@@ -20,7 +20,7 @@ def test_invalid_dem_type():
 def test_default_output_format():
     params = Topography.DEFAULT.copy()
     params.pop("output_format")
-    assert "output_format" in params.keys() is False
+    assert "output_format" not in params.keys()
 
     topo = Topography(**params)
     assert topo.output_format == "GTiff"


### PR DESCRIPTION
The [OT API server](https://portal.opentopography.org/apidocs/) sets a default output format of `GTiff` for global and USGS raster datasets. This option should be passed along to users of *bmi-topography*.