### PR TITLE
Construct download URL before fetching data

### DIFF
--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -128,16 +128,15 @@ class Topography:
         return Topography.base_url() + self._server
 
     def _build_filename(self):
-        return Path(
-            self.cache_dir
-        ) / "{dem_type}_{south}_{west}_{north}_{east}.{ext}".format(
-            dem_type=self.dem_type,
-            south=self.bbox.south,
-            north=self.bbox.north,
-            west=self.bbox.west,
-            east=self.bbox.east,
-            ext=self.file_extension,
+        filename = (
+            f"{self.dem_type}"
+            f"_{self.bbox.south}"
+            f"_{self.bbox.west}"
+            f"_{self.bbox.north}"
+            f"_{self.bbox.east}"
+            f".{self.file_extension}"
         )
+        return Path(self.cache_dir) / filename
 
     def fetch(self):
         """Download and locally store topography data.

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -1,7 +1,7 @@
 """Base class to access elevation data"""
 
 import os
-import urllib
+from urllib.parse import urlunparse, urlencode, ParseResult
 import warnings
 from collections import namedtuple
 from pathlib import Path
@@ -14,18 +14,13 @@ from rasterio.errors import CRSError
 from .api_key import ApiKey
 from .bbox import BoundingBox
 
-UrlComponents = namedtuple(
-    typename="UrlComponents",
-    field_names=["scheme", "netloc", "url", "path", "query", "fragment"],
-)
-
 
 class Topography:
     """Fetch and cache land elevation data from OpenTopography."""
 
     SCHEME = "https"
     NETLOC = "portal.opentopography.org"
-    SERVER_BASE = "/API"
+    SERVER_BASE = "API"
     SERVER_NAME = {"global": "/globaldem", "usgs": "/usgsdem"}
 
     DEFAULT = {
@@ -128,15 +123,15 @@ class Topography:
 
     @staticmethod
     def base_url():
-        url_components = UrlComponents(
+        url_components = ParseResult(
             scheme=Topography.SCHEME,
             netloc=Topography.NETLOC,
-            url="",
             path="",
+            params="",
             query="",
             fragment="",
         )
-        return urllib.parse.urlunparse(url_components)
+        return urlunparse(url_components)
 
     def _build_filename(self):
         filename = (
@@ -169,16 +164,16 @@ class Topography:
 
     def _build_url(self):
         query_params = self._build_query()
-        url_components = UrlComponents(
+        url_components = ParseResult(
             scheme=Topography.SCHEME,
             netloc=Topography.NETLOC,
-            url=self.server,
-            path="",
-            query=urllib.parse.urlencode(query_params),
+            path=self.server,
+            params="",
+            query=urlencode(query_params),
             fragment="",
         )
 
-        return urllib.parse.urlunparse(url_components)
+        return urlunparse(url_components)
 
     @property
     def url(self):

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -150,17 +150,18 @@ class Topography:
         return Path(self.cache_dir) / filename
 
     def _build_query(self):
-        params = {
-            "south": self.bbox.south,
-            "north": self.bbox.north,
-            "west": self.bbox.west,
-            "east": self.bbox.east,
-            "outputFormat": self.output_format,
-        }
-        if "usgs" in self._server:
+        params = {}
+        if "usgs" in self.server:
             params["datasetName"] = self.dem_type
         else:
             params["demtype"] = self.dem_type
+
+        params["south"] = self.bbox.south
+        params["north"] = self.bbox.north
+        params["west"] = self.bbox.west
+        params["east"] = self.bbox.east
+        params["outputFormat"] = self.output_format
+
         if self._api_key:
             params["API_Key"] = str(self._api_key)
 

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -128,9 +128,15 @@ class Topography:
 
     @staticmethod
     def base_url():
-        return urllib.parse.urlunparse(
-            (Topography.SCHEME, Topography.NETLOC, "", "", "", "")
+        url_components = UrlComponents(
+            scheme=Topography.SCHEME,
+            netloc=Topography.NETLOC,
+            url="",
+            path="",
+            query="",
+            fragment="",
         )
+        return urllib.parse.urlunparse(url_components)
 
     def _build_filename(self):
         filename = (

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -3,6 +3,7 @@
 import os
 import urllib
 import warnings
+from collections import namedtuple
 from pathlib import Path
 
 import requests
@@ -12,6 +13,11 @@ from rasterio.errors import CRSError
 
 from .api_key import ApiKey
 from .bbox import BoundingBox
+
+UrlComponents = namedtuple(
+    typename="UrlComponents",
+    field_names=["scheme", "netloc", "url", "path", "query", "fragment"],
+)
 
 
 class Topography:
@@ -160,14 +166,15 @@ class Topography:
 
     def _build_url(self):
         query_params = self._build_query()
-        url_components = (
-            Topography.SCHEME,
-            Topography.NETLOC,
-            self.server,
-            "",
-            urllib.parse.urlencode(query_params),
-            "",
+        url_components = UrlComponents(
+            scheme=Topography.SCHEME,
+            netloc=Topography.NETLOC,
+            url=self.server,
+            path="",
+            query=urllib.parse.urlencode(query_params),
+            fragment="",
         )
+
         return urllib.parse.urlunparse(url_components)
 
     def fetch(self):

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -1,10 +1,9 @@
 """Base class to access elevation data"""
 
 import os
-from urllib.parse import urlunparse, urlencode, ParseResult
 import warnings
-from collections import namedtuple
 from pathlib import Path
+from urllib.parse import ParseResult, urlencode, urlunparse
 
 import requests
 import rioxarray

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -88,6 +88,8 @@ class Topography:
 
         self._bbox = BoundingBox((south, west), (north, east))
 
+        self._url = self._build_url()
+
         self._da = None
 
         if cache_dir is None:
@@ -113,6 +115,10 @@ class Topography:
     @property
     def bbox(self):
         return self._bbox
+
+    @property
+    def url(self):
+        return self._url
 
     @property
     def cache_dir(self):
@@ -155,6 +161,18 @@ class Topography:
 
         return params
 
+    def _build_url(self):
+        query_params = self._build_query()
+        url_components = (
+            Topography.SCHEME,
+            Topography.NETLOC,
+            self.server,
+            "",
+            urllib.parse.urlencode(query_params),
+            "",
+        )
+        return urllib.parse.urlunparse(url_components)
+
     def fetch(self):
         """Download and locally store topography data.
 
@@ -164,9 +182,8 @@ class Topography:
         fname = self._build_filename()
         if not fname.is_file():
             self.cache_dir.mkdir(exist_ok=True)
-            query_params = self._build_query()
 
-            response = requests.get(self.data_url(), params=query_params, stream=True)
+            response = requests.get(self.url, stream=True)
 
             if response.status_code == 401:
                 if self._api_key.source == "demo":

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -130,9 +130,6 @@ class Topography:
             (Topography.SCHEME, Topography.NETLOC, "", "", "", "")
         )
 
-    def data_url(self):
-        return Topography.base_url() + self._server
-
     def _build_filename(self):
         filename = (
             f"{self.dem_type}"

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -127,13 +127,8 @@ class Topography:
     def data_url(self):
         return Topography.base_url() + self._server
 
-    def fetch(self):
-        """Download and locally store topography data.
-
-        Returns:
-            pathlib.Path: The path to the downloaded file
-        """
-        fname = Path(
+    def _build_filename(self):
+        return Path(
             self.cache_dir
         ) / "{dem_type}_{south}_{west}_{north}_{east}.{ext}".format(
             dem_type=self.dem_type,
@@ -144,6 +139,13 @@ class Topography:
             ext=self.file_extension,
         )
 
+    def fetch(self):
+        """Download and locally store topography data.
+
+        Returns:
+            pathlib.Path: The path to the downloaded file
+        """
+        fname = self._build_filename()
         if not fname.is_file():
             self.cache_dir.mkdir(exist_ok=True)
             params = {

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -123,10 +123,6 @@ class Topography:
         return self._bbox
 
     @property
-    def url(self):
-        return self._url
-
-    @property
     def cache_dir(self):
         return self._cache_dir
 
@@ -176,6 +172,10 @@ class Topography:
         )
 
         return urllib.parse.urlunparse(url_components)
+
+    @property
+    def url(self):
+        return self._url
 
     def fetch(self):
         """Download and locally store topography data.

--- a/tests/test_topography.py
+++ b/tests/test_topography.py
@@ -82,22 +82,6 @@ def test_clear_cache(tmpdir):
             assert not file.is_file()
 
 
-@pytest.mark.parametrize("server_name", tuple(Topography.SERVER_NAME.values()))
-def test_data_url(server_name):
-    if "usgs" in server_name:
-        dem_type = "USGS30m"
-    else:
-        dem_type = "NASADEM"
-
-    params = Topography.DEFAULT.copy()
-    params["dem_type"] = dem_type
-    topo = Topography(**params)
-
-    server = Topography.SERVER_BASE + server_name
-    r = topo.data_url()
-    assert r == Topography.base_url() + server
-
-
 @pytest.mark.parametrize("dem_type", Topography.VALID_DEM_TYPES)
 def test_fetch(dem_type):
     params = Topography.DEFAULT.copy()


### PR DESCRIPTION
The purpose of this PR is to allow a Topography instance to show the URL it will use to download a dataset from OT before actually downloading it. Surprisingly, Topography can't currently do this!

To make this work, I refactored the `fetch` method to gain access to the query parameters of the URL. (The refactoring also helped clean up `fetch`.) I then built the download URL with *urllib* and added a new `url` property to Topography to store the result. The `url` property is used by `requests.get` in the `fetch` method to download the dataset. 

As a side effect of these changes, I no longer need the `data_url` method, so I removed it.

This fixes #91.