### PR TITLE
Check for missing or incomplete bounding box on instantiation

### DIFF
--- a/bmi_topography/errors.py
+++ b/bmi_topography/errors.py
@@ -20,3 +20,9 @@ class BadApiKeySource(BmiTopographyError):
     """Raise for an invalid API key source."""
 
     pass
+
+
+class BoundingBoxError(BmiTopographyError):
+    """Raise for an invalid or incomplete bounding box."""
+
+    pass

--- a/bmi_topography/topography.py
+++ b/bmi_topography/topography.py
@@ -12,6 +12,7 @@ from rasterio.errors import CRSError
 
 from .api_key import ApiKey
 from .bbox import BoundingBox
+from .errors import BoundingBoxError
 
 
 class Topography:
@@ -86,6 +87,10 @@ class Topography:
                 % [k for k in Topography.VALID_OUTPUT_FORMATS.keys()]
             )
 
+        if None in (south, west, north, east):
+            raise BoundingBoxError(
+                "'north', 'east', 'south', and 'west' parameters are required"
+            )
         self._bbox = BoundingBox((south, west), (north, east))
 
         self._url = self._build_url()

--- a/tests/test_topography.py
+++ b/tests/test_topography.py
@@ -9,6 +9,7 @@ import requests
 
 from bmi_topography import Topography
 from bmi_topography.api_key import ApiKey
+from bmi_topography.errors import BoundingBoxError
 
 CENTER_LAT = 40.0
 CENTER_LON = -105.0
@@ -18,6 +19,18 @@ WIDTH = 0.01
 def test_invalid_dem_type():
     with pytest.raises(ValueError):
         Topography(dem_type="foo", output_format=Topography.DEFAULT["output_format"])
+
+
+def test_missing_bbox():
+    params = Topography.DEFAULT.copy()
+    with pytest.raises(BoundingBoxError):
+        Topography(params["dem_type"])
+
+
+def test_incomplete_bbox():
+    params = Topography.DEFAULT.copy()
+    with pytest.raises(BoundingBoxError):
+        Topography(params["dem_type"], south=CENTER_LAT, east=CENTER_LON)
 
 
 def test_default_output_format():

--- a/tests/test_topography.py
+++ b/tests/test_topography.py
@@ -21,18 +21,6 @@ def test_invalid_dem_type():
         Topography(dem_type="foo", output_format=Topography.DEFAULT["output_format"])
 
 
-def test_missing_bbox():
-    params = Topography.DEFAULT.copy()
-    with pytest.raises(BoundingBoxError):
-        Topography(params["dem_type"])
-
-
-def test_incomplete_bbox():
-    params = Topography.DEFAULT.copy()
-    with pytest.raises(BoundingBoxError):
-        Topography(params["dem_type"], south=CENTER_LAT, east=CENTER_LON)
-
-
 def test_default_output_format():
     params = Topography.DEFAULT.copy()
     params.pop("output_format")
@@ -45,6 +33,18 @@ def test_default_output_format():
 def test_invalid_output_format():
     with pytest.raises(ValueError):
         Topography(dem_type=Topography.DEFAULT["dem_type"], output_format="foo")
+
+
+def test_missing_bbox():
+    params = Topography.DEFAULT.copy()
+    with pytest.raises(BoundingBoxError):
+        Topography(params["dem_type"])
+
+
+def test_incomplete_bbox():
+    params = Topography.DEFAULT.copy()
+    with pytest.raises(BoundingBoxError):
+        Topography(params["dem_type"], south=CENTER_LAT, east=CENTER_LON)
 
 
 def test_valid_bbox():
@@ -95,6 +95,7 @@ def test_clear_cache(tmpdir):
             assert not file.is_file()
 
 
+@pytest.mark.skipif("NO_FETCH" in os.environ, reason="NO_FETCH is set")
 @pytest.mark.parametrize("dem_type", Topography.VALID_DEM_TYPES)
 def test_fetch(dem_type):
     params = Topography.DEFAULT.copy()
@@ -115,6 +116,7 @@ def test_fetch(dem_type):
     assert topo._api_key.is_invalid_test_key() is True
 
 
+@pytest.mark.skipif("NO_FETCH" in os.environ, reason="NO_FETCH is set")
 def test_fetch_load_default(tmpdir):
     with tmpdir.as_cwd():
         topo = Topography(**Topography.DEFAULT)


### PR DESCRIPTION
This PR adds a check for all four bounding box parameters (`north`, `south`, `east`, `west`) when creating a new Topography instance, raising an exception if they're not present.
For example:

```python
>>> from bmi_topography import Topography
>>> topo = Topography("COP30")
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    topo = Topography("COP30")
  File "/Users/mpiper/projects/bmi-topography/bmi_topography/topography.py", line 91, in __init__
    raise BoundingBoxError(
        "'north', 'east', 'south', and 'west' parameters are required"
    )
bmi_topography.errors.BoundingBoxError: 'north', 'east', 'south', and 'west' parameters are required
```

This fixes #93.