### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
   - id: blackdoc-autoupdate-black
 
 - repo: https://github.com/pycqa/flake8
-  rev: 7.0.0
+  rev: 7.3.0
   hooks:
   - id: flake8
     additional_dependencies:
@@ -54,7 +54,7 @@ repos:
     - flake8-simplify
 
 - repo: https://github.com/nbQA-dev/nbQA
-  rev: 1.8.5
+  rev: 1.9.1
   hooks:
     - id: nbqa-pyupgrade
       args: ["--py310-plus"]
@@ -63,7 +63,7 @@ repos:
       args: ["--extend-ignore=E402"]
 
 - repo: https://github.com/kynan/nbstripout
-  rev: 0.7.1
+  rev: 0.9.1
   hooks:
     - id: nbstripout
       description: Strip output from jupyter notebooks
@@ -76,7 +76,7 @@ repos:
     args: [--py310-plus]
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.13.2
+  rev: 8.0.1
   hooks:
   - id: isort
     name: isort (python)
@@ -84,7 +84,7 @@ repos:
     types: [python]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v6.0.0
   hooks:
     - id: check-builtin-literals
     - id: check-added-large-files


### PR DESCRIPTION
The *pre-commit* hooks were out-of-date, so I've updated them. We should probably get rid of this workflow and use *pre-commit.ci* instead.