### PR TITLE
Add a `--cache-dir` CLI option

### DIFF
--- a/bmi_topography/cli.py
+++ b/bmi_topography/cli.py
@@ -51,13 +51,20 @@ from .topography import Topography
     show_default=True,
 )
 @click.option(
+    "--cache-dir",
+    type=click.Path(exists=False, file_okay=False, dir_okay=True, readable=True, writable=True),
+    default=Topography.DEFAULT["cache_dir"],
+    help="Directory to store data files downloaded from OpenTopography.",
+    show_default=True,
+)
+@click.option(
     "--api-key",
     type=str,
     help="OpenTopography API key.",
     show_default=True,
 )
 @click.option("--no-fetch", is_flag=True, help="Do not fetch data from server.")
-def main(quiet, dem_type, south, north, west, east, output_format, api_key, no_fetch):
+def main(quiet, dem_type, south, north, west, east, output_format, cache_dir, api_key, no_fetch):
     """Fetch and cache land elevation data from OpenTopography
 
     Some datasets require an OpenTopography API key. You can find instructions
@@ -72,7 +79,7 @@ def main(quiet, dem_type, south, north, west, east, output_format, api_key, no_f
     directory, or 3) through the `--api-key` option.
     """
     topo = Topography(
-        dem_type, south, north, west, east, output_format, api_key=api_key
+        dem_type, south, north, west, east, output_format, cache_dir=cache_dir, api_key=api_key
     )
     if not no_fetch:
         if not quiet:

--- a/bmi_topography/cli.py
+++ b/bmi_topography/cli.py
@@ -52,7 +52,9 @@ from .topography import Topography
 )
 @click.option(
     "--cache-dir",
-    type=click.Path(exists=False, file_okay=False, dir_okay=True, readable=True, writable=True),
+    type=click.Path(
+        exists=False, file_okay=False, dir_okay=True, readable=True, writable=True
+    ),
     default=Topography.DEFAULT["cache_dir"],
     help="Directory to store data files downloaded from OpenTopography.",
     show_default=True,
@@ -64,7 +66,18 @@ from .topography import Topography
     show_default=True,
 )
 @click.option("--no-fetch", is_flag=True, help="Do not fetch data from server.")
-def main(quiet, dem_type, south, north, west, east, output_format, cache_dir, api_key, no_fetch):
+def main(
+    quiet,
+    dem_type,
+    south,
+    north,
+    west,
+    east,
+    output_format,
+    cache_dir,
+    api_key,
+    no_fetch,
+):
     """Fetch and cache land elevation data from OpenTopography
 
     Some datasets require an OpenTopography API key. You can find instructions
@@ -79,7 +92,14 @@ def main(quiet, dem_type, south, north, west, east, output_format, cache_dir, ap
     directory, or 3) through the `--api-key` option.
     """
     topo = Topography(
-        dem_type, south, north, west, east, output_format, cache_dir=cache_dir, api_key=api_key
+        dem_type,
+        south,
+        north,
+        west,
+        east,
+        output_format,
+        cache_dir=cache_dir,
+        api_key=api_key,
     )
     if not no_fetch:
         if not quiet:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -129,3 +129,19 @@ def test_api_key_is_used():
     runner = CliRunner()
     result = runner.invoke(main, ["--api-key=foobar", "--no-fetch"])
     assert result.exit_code == 0
+
+
+@pytest.mark.skipif("NO_FETCH" in os.environ, reason="NO_FETCH is set")
+@pytest.mark.parametrize("good_dir", ["./sooperdooper", "~/sooperdooper"])
+def test_cache_dir_writable_dir(good_dir):
+    runner = CliRunner()
+    result = runner.invoke(main, [f"--cache-dir={good_dir}"])
+    assert result.exit_code == 0
+    assert "sooperdooper" in result.output
+
+
+def test_cache_dir_unwritable_dir():
+    runner = CliRunner()
+    result = runner.invoke(main, ["--cache-dir=/usr"])
+    assert result.exit_code != 0
+    assert "is not writable" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 import os
 import pathlib
+import sys
 
 import pytest
 from click.testing import CliRunner

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,6 +140,7 @@ def test_cache_dir_writable_dir(good_dir):
     assert "sooperdooper" in result.output
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="doesn't work on Windows")
 def test_cache_dir_unwritable_dir():
     runner = CliRunner()
     result = runner.invoke(main, ["--cache-dir=/usr"])


### PR DESCRIPTION
All of the Topography parameters have analogous command-line options except for `cache_dir`. This PR fixes that, adding a `--cache-dir` CLI option.