### PR TITLE
Add `--config-file` CLI option

### DIFF
--- a/bmi_topography/cli.py
+++ b/bmi_topography/cli.py
@@ -2,72 +2,134 @@
 
 import click
 
+from .config import load_config
 from .topography import Topography
+
+# Names of options that are mutually exclusive with --config-file
+_CONFIG_FILE_EXCLUSIVE = {
+    "dem_type",
+    "south",
+    "north",
+    "west",
+    "east",
+    "output_format",
+    "cache_dir",
+    "api_key",
+}
+
+
+class MutuallyExclusiveOption(click.Option):
+    """A Click option that is mutually exclusive with --config-file."""
+
+    def __init__(self, *args, **kwargs):
+        self.mutually_exclusive_with = kwargs.pop("mutually_exclusive_with", [])
+        super().__init__(*args, **kwargs)
+
+    def handle_parse_result(self, ctx, opts, args):
+        current = self.name in opts and opts[self.name] is not None
+        for mutex_opt in self.mutually_exclusive_with:
+            if mutex_opt in opts and opts[mutex_opt] is not None:
+                if current:
+                    raise click.UsageError(
+                        f"'--{self.name.replace('_', '-')}' cannot be used together "
+                        f"with '--{mutex_opt.replace('_', '-')}'."
+                    )
+        return super().handle_parse_result(ctx, opts, args)
 
 
 @click.command()
 @click.version_option()
 @click.option("-q", "--quiet", is_flag=True, help="Enables quiet mode.")
 @click.option(
+    "--config-file",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True),
+    default=None,
+    help=(
+        "Path to a YAML configuration file. "
+        "Mutually exclusive with --dem-type, --south, --north, --west, --east, "
+        "--output-format, --cache-dir, and --api-key."
+    ),
+    cls=MutuallyExclusiveOption,
+    mutually_exclusive_with=list(_CONFIG_FILE_EXCLUSIVE),
+)
+@click.option(
     "--dem-type",
     type=click.Choice(Topography.VALID_DEM_TYPES, case_sensitive=True),
-    default=Topography.DEFAULT["dem_type"],
+    default=None,
     help="The global raster dataset.",
     show_default=True,
+    cls=MutuallyExclusiveOption,
+    mutually_exclusive_with=["config_file"],
 )
 @click.option(
     "--south",
     type=click.FloatRange(-90, 90),
-    default=Topography.DEFAULT["south"],
+    default=None,
     help="WGS 84 bounding box south coordinate, in degrees.",
     show_default=True,
+    cls=MutuallyExclusiveOption,
+    mutually_exclusive_with=["config_file"],
 )
 @click.option(
     "--north",
     type=click.FloatRange(-90, 90),
-    default=Topography.DEFAULT["north"],
+    default=None,
     help="WGS 84 bounding box north coordinate, in degrees.",
     show_default=True,
+    cls=MutuallyExclusiveOption,
+    mutually_exclusive_with=["config_file"],
 )
 @click.option(
     "--west",
     type=click.FloatRange(-180, 180),
-    default=Topography.DEFAULT["west"],
+    default=None,
     help="WGS 84 bounding box west coordinate, in degrees.",
     show_default=True,
+    cls=MutuallyExclusiveOption,
+    mutually_exclusive_with=["config_file"],
 )
 @click.option(
     "--east",
     type=click.FloatRange(-180, 180),
-    default=Topography.DEFAULT["east"],
+    default=None,
     help="WGS 84 bounding box east coordinate, in degrees.",
     show_default=True,
+    cls=MutuallyExclusiveOption,
+    mutually_exclusive_with=["config_file"],
 )
 @click.option(
     "--output-format",
     type=click.Choice(Topography.VALID_OUTPUT_FORMATS.keys(), case_sensitive=True),
-    default=Topography.DEFAULT["output_format"],
+    default=None,
     help="Output file format.",
     show_default=True,
+    cls=MutuallyExclusiveOption,
+    mutually_exclusive_with=["config_file"],
 )
 @click.option(
     "--cache-dir",
     type=click.Path(
         exists=False, file_okay=False, dir_okay=True, readable=True, writable=True
     ),
-    default=Topography.DEFAULT["cache_dir"],
+    default=None,
     help="Directory to store data files downloaded from OpenTopography.",
     show_default=True,
+    cls=MutuallyExclusiveOption,
+    mutually_exclusive_with=["config_file"],
 )
 @click.option(
     "--api-key",
     type=str,
+    default=None,
     help="OpenTopography API key.",
     show_default=True,
+    cls=MutuallyExclusiveOption,
+    mutually_exclusive_with=["config_file"],
 )
 @click.option("--no-fetch", is_flag=True, help="Do not fetch data from server.")
 def main(
     quiet,
+    config_file,
     dem_type,
     south,
     north,
@@ -91,16 +153,27 @@ def main(
     ".opentopography.txt" located either in your current directory or your home
     directory, or 3) through the `--api-key` option.
     """
-    topo = Topography(
-        dem_type,
-        south,
-        north,
-        west,
-        east,
-        output_format,
-        cache_dir=cache_dir,
-        api_key=api_key,
-    )
+    if config_file is not None:
+        params = load_config(config_file)
+    else:
+        defaults = Topography.DEFAULT
+        params = {
+            "dem_type": dem_type if dem_type is not None else defaults["dem_type"],
+            "south": south if south is not None else defaults["south"],
+            "north": north if north is not None else defaults["north"],
+            "west": west if west is not None else defaults["west"],
+            "east": east if east is not None else defaults["east"],
+            "output_format": (
+                output_format
+                if output_format is not None
+                else defaults["output_format"]
+            ),
+            "cache_dir": cache_dir if cache_dir is not None else defaults["cache_dir"],
+            "api_key": api_key,
+        }
+
+    topo = Topography(**params)
+
     if not no_fetch:
         if not quiet:
             click.secho("Fetching data...", fg="yellow", err=True)

--- a/bmi_topography/cli.py
+++ b/bmi_topography/cli.py
@@ -159,19 +159,17 @@ def main(
     else:
         defaults = Topography.DEFAULT
         params = {
-            "dem_type": dem_type if dem_type is not None else defaults["dem_type"],
-            "south": south if south is not None else defaults["south"],
-            "north": north if north is not None else defaults["north"],
-            "west": west if west is not None else defaults["west"],
-            "east": east if east is not None else defaults["east"],
-            "output_format": (
-                output_format
-                if output_format is not None
-                else defaults["output_format"]
-            ),
-            "cache_dir": cache_dir if cache_dir is not None else defaults["cache_dir"],
-            "api_key": api_key,
-        }
+            key: val if (val := locals()[key]) is not None else defaults[key]
+            for key in (
+                "dem_type",
+                "south",
+                "north",
+                "west",
+                "east",
+                "output_format",
+                "cache_dir",
+            )
+        } | {"api_key": api_key}
 
     topo = Topography(**params)
 

--- a/bmi_topography/cli.py
+++ b/bmi_topography/cli.py
@@ -159,17 +159,19 @@ def main(
     else:
         defaults = Topography.DEFAULT
         params = {
-            key: val if (val := locals()[key]) is not None else defaults[key]
-            for key in (
-                "dem_type",
-                "south",
-                "north",
-                "west",
-                "east",
-                "output_format",
-                "cache_dir",
-            )
-        } | {"api_key": api_key}
+            "dem_type": dem_type if dem_type is not None else defaults["dem_type"],
+            "south": south if south is not None else defaults["south"],
+            "north": north if north is not None else defaults["north"],
+            "west": west if west is not None else defaults["west"],
+            "east": east if east is not None else defaults["east"],
+            "output_format": (
+                output_format
+                if output_format is not None
+                else defaults["output_format"]
+            ),
+            "cache_dir": cache_dir if cache_dir is not None else defaults["cache_dir"],
+            "api_key": api_key,
+        }
 
     topo = Topography(**params)
 

--- a/bmi_topography/cli.py
+++ b/bmi_topography/cli.py
@@ -18,6 +18,7 @@ _CONFIG_FILE_EXCLUSIVE = {
 }
 
 
+# Based on https://stackoverflow.com/a/37491504/1563298.
 class MutuallyExclusiveOption(click.Option):
     """A Click option that is mutually exclusive with --config-file."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -147,3 +147,59 @@ def test_cache_dir_unwritable_dir():
     result = runner.invoke(main, ["--cache-dir=/usr"])
     assert result.exit_code != 0
     assert "is not writable" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --config-file tests
+# ---------------------------------------------------------------------------
+
+CONFIG_YAML = """\
+bmi-topography:
+  dem_type: SRTMGL3
+  south: 36.738884
+  north: 38.091337
+  west: -120.168457
+  east: -118.465576
+  output_format: GTiff
+  cache_dir: "."
+"""
+
+
+def test_config_file_no_fetch(tmp_path):
+    """--config-file with --no-fetch should succeed."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(CONFIG_YAML)
+    runner = CliRunner()
+    result = runner.invoke(main, [f"--config-file={cfg}", "--no-fetch"])
+    assert result.exit_code == 0, result.output
+
+
+def test_config_file_nonexistent():
+    """Passing a path that does not exist should fail."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["--config-file=/no/such/file.yaml", "--no-fetch"])
+    assert result.exit_code != 0
+
+
+@pytest.mark.parametrize(
+    "extra_opt",
+    [
+        "--dem-type=SRTMGL3",
+        "--south=36.0",
+        "--north=38.0",
+        "--west=-120.0",
+        "--east=-118.0",
+        "--output-format=GTiff",
+        "--cache-dir=.",
+        "--api-key=foobar",
+    ],
+)
+def test_config_file_mutually_exclusive(tmp_path, extra_opt):
+    """--config-file must not be combined with any individual parameter option."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(CONFIG_YAML)
+    runner = CliRunner()
+    result = runner.invoke(main, [f"--config-file={cfg}", extra_opt, "--no-fetch"])
+    assert result.exit_code != 0, (
+        f"Expected non-zero exit when combining --config-file with {extra_opt}"
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -200,6 +200,6 @@ def test_config_file_mutually_exclusive(tmp_path, extra_opt):
     cfg.write_text(CONFIG_YAML)
     runner = CliRunner()
     result = runner.invoke(main, [f"--config-file={cfg}", extra_opt, "--no-fetch"])
-    assert result.exit_code != 0, (
-        f"Expected non-zero exit when combining --config-file with {extra_opt}"
-    )
+    assert (
+        result.exit_code != 0
+    ), f"Expected non-zero exit when combining --config-file with {extra_opt}"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,10 @@
 """Test the config module"""
 
+import pytest
+
 from bmi_topography import Topography
 from bmi_topography.config import load_config
+from bmi_topography.errors import BadConfigFileError
 
 CONFIG_FILE = "config.yaml"
 DEM_TYPE = "SRTMGL3"
@@ -12,6 +15,14 @@ def test_load_config(shared_datadir):
     conf = load_config(shared_datadir / CONFIG_FILE)
     assert conf["dem_type"] == DEM_TYPE
     assert conf["output_format"] == OUTPUT_FORMAT
+
+
+def test_config_file_missing_key(tmp_path):
+    """Config file without 'bmi-topography' key should fail with a helpful message."""
+    cfg = tmp_path / "bad.yaml"
+    cfg.write_text("other_key:\n  dem_type: SRTMGL3\n")
+    with pytest.raises(BadConfigFileError):
+        load_config(cfg)
 
 
 def test_set_default_config():


### PR DESCRIPTION
I asked Claude for help with #7. Here's my prompt:

> Address https://github.com/csdms/bmi-topography/issues/7 by adding an exclusive `--config-file` option to the *bmi-topography* CLI.

Claude made a `MutuallyExclusiveOption` class—a thin click.Option subclass that raises a `UsageError` at parse time if the option it's attached to is provided alongside any of its declared mutual-exclusion peers. It added a new `--config-file` option declared with `cls=MutuallyExclusiveOption` and `mutually_exclusive_with=[list of all individual param options]`.

All individual param options (`--dem-type`, `--south`, etc.) had their default values changed from hard-coded constants to `None`. This is necessary so Click can distinguish "user explicitly passed this" from "user didn't pass anything". The `main()` body then fills in `Topography.DEFAULT` values when `--config_file` is `None` and a specific option wasn't provided.

Through a DuckDuckGo search, I found [the likely source for Claude's answer](https://stackoverflow.com/a/37491504/1563298), and I added this attribution to the code.

I made a few extra tweaks to what Claude returned.

This fixes #7.