### PR TITLE
Fix read-only `--cache-dir` CLI tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -198,6 +198,4 @@ def test_config_file_mutually_exclusive(tmp_path, extra_opt):
     cfg.write_text(CONFIG_YAML)
     runner = CliRunner()
     result = runner.invoke(main, [f"--config-file={cfg}", extra_opt, "--no-fetch"])
-    assert result.exit_code != 0, (
-        f"Expected non-zero exit when combining --config-file with {extra_opt}"
-    )
+    assert result.exit_code != 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 import os
 import pathlib
 import stat
+import sys
 
 import pytest
 from click.testing import CliRunner
@@ -132,6 +133,7 @@ def test_api_key_is_used():
     assert result.exit_code == 0
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="no read-only on Windows")
 def test_cache_dir_is_readonly(tmpdir):
     readonly_dir = tmpdir.mkdir("readonly")
     readonly_dir.chmod(stat.S_IRUSR | stat.S_IXUSR)  # r-x, no write
@@ -196,6 +198,6 @@ def test_config_file_mutually_exclusive(tmp_path, extra_opt):
     cfg.write_text(CONFIG_YAML)
     runner = CliRunner()
     result = runner.invoke(main, [f"--config-file={cfg}", extra_opt, "--no-fetch"])
-    assert (
-        result.exit_code != 0
-    ), f"Expected non-zero exit when combining --config-file with {extra_opt}"
+    assert result.exit_code != 0, (
+        f"Expected non-zero exit when combining --config-file with {extra_opt}"
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@
 
 import os
 import pathlib
-import sys
+import stat
 
 import pytest
 from click.testing import CliRunner
@@ -132,21 +132,17 @@ def test_api_key_is_used():
     assert result.exit_code == 0
 
 
-@pytest.mark.skipif("NO_FETCH" in os.environ, reason="NO_FETCH is set")
-@pytest.mark.parametrize("good_dir", ["./sooperdooper", "~/sooperdooper"])
-def test_cache_dir_writable_dir(good_dir):
-    runner = CliRunner()
-    result = runner.invoke(main, [f"--cache-dir={good_dir}"])
-    assert result.exit_code == 0
-    assert "sooperdooper" in result.output
+def test_cache_dir_is_readonly(tmpdir):
+    readonly_dir = tmpdir.mkdir("readonly")
+    readonly_dir.chmod(stat.S_IRUSR | stat.S_IXUSR)  # r-x, no write
 
-
-@pytest.mark.skipif(sys.platform == "win32", reason="doesn't work on Windows")
-def test_cache_dir_unwritable_dir():
-    runner = CliRunner()
-    result = runner.invoke(main, ["--cache-dir=/usr"])
-    assert result.exit_code != 0
-    assert "is not writable" in result.output
+    try:
+        runner = CliRunner()
+        result = runner.invoke(main, ["--cache-dir=" + str(readonly_dir), "--no-fetch"])
+        assert result.exit_code != 0
+        assert "not writable" in result.output
+    finally:
+        readonly_dir.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)  # rwx
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
I had written a pair of tests for the `--cache-dir` CLI option. One unwittingly duplicated a test in the *test_topography* module, while the other relied on a directory in the local testing filesystem. I've removed the first, and improved the second, using the *pytest* `tmpdir` fixture to create a read-only directory.